### PR TITLE
Add release digest tracking and filterable changelog

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -120,6 +120,10 @@
 
   <div class="container">
     <h1>Warped Pinball Firmware Changelog</h1>
+    <div style="text-align:center;margin-bottom:10px;">
+      <label><input type="checkbox" id="show-beta"> Show beta builds</label>
+      <label style="margin-left:10px;"><input type="checkbox" id="show-dev"> Show dev builds</label>
+    </div>
 
     <div>
       <div id="sys11-tab" class="tab active" onclick="showTab('sys11')">System 11</div>
@@ -141,17 +145,26 @@
 
   <script>
     // Fetch the release data
+    const releaseCache = {};
+    let currentProduct = 'sys11';
     async function fetchData(product) {
+      if (releaseCache[product]) return releaseCache[product];
       const response = await fetch(`https://warped-pinball.github.io/website/docs/${product}/main.json`);
-      return response.json();
+      const data = await response.json();
+      releaseCache[product] = data;
+      return data;
     }
 
     // Render release data in Markdown-like format
     function renderReleases(data, product) {
+      const showBeta = document.getElementById('show-beta').checked;
+      const showDev = document.getElementById('show-dev').checked;
       const container = document.getElementById(`${product}-releases`);
-      container.innerHTML = '';  // Clear existing entries
+      container.innerHTML = '';
 
       data.forEach(release => {
+        if (release.type === 'beta' && !showBeta) return;
+        if (release.type === 'dev' && !showDev) return;
         const div = document.createElement("div");
         div.className = "release-item";
         const releaseLink = `<a href="https://github.com/warped-pinball/vector/releases/tag/${release.version}" target="_blank">${release.version}</a>`;
@@ -160,7 +173,7 @@
         const releaseNotes = marked.parse(release.notes || "No release notes provided");
 
         // Set the correct download link (update.json)
-        const downloadLink = `https://github.com/warped-pinball/vector/releases/download/${release.version}/update.json`;
+        const downloadLink = release.url;
 
         div.innerHTML = `
           <strong>${releaseLink}</strong><br>
@@ -174,15 +187,13 @@
 
     // Show the correct tab
     function showTab(product) {
-      // Hide all tab content and deactivate tabs
+      currentProduct = product;
       document.querySelectorAll('.tab-content').forEach(tabContent => tabContent.classList.remove('active'));
       document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
 
-      // Activate the clicked tab and content
       document.getElementById(product + '-tab').classList.add('active');
       document.getElementById(product).classList.add('active');
 
-      // Load data for that product
       fetchData(product).then(data => renderReleases(data, product));
     }
 
@@ -196,6 +207,13 @@
       document.body.removeChild(textarea);
       alert("Download link copied!");
     }
+
+    document.getElementById('show-beta').addEventListener('change', () => {
+      fetchData(currentProduct).then(data => renderReleases(data, currentProduct));
+    });
+    document.getElementById('show-dev').addEventListener('change', () => {
+      fetchData(currentProduct).then(data => renderReleases(data, currentProduct));
+    });
 
     // Initial load for sys11
     showTab('sys11');


### PR DESCRIPTION
## Summary
- enhance `generate.py` to compute SHA256 digests of both `update.json` and
  `update_wpc.json`
- create `docs/builds.json` containing metadata for every update file
- allow optional beta/dev builds and skip duplicate production updates
- add filtering checkboxes and caching logic to `index.html`

## Testing
- `GITHUB_TOKEN=fake_token python3 scripts/generate.py --owner warped-pinball --repo vector --out-dir docs` *(fails: BadCredentialsException)*

------
https://chatgpt.com/codex/tasks/task_e_6854a8140e508330b289eaa65fc6ecd2