### PR TITLE
Fix release display order

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -162,7 +162,10 @@
       const container = document.getElementById(`${product}-releases`);
       container.innerHTML = '';
 
-      data.forEach(release => {
+      // Sort releases so the newest appear first
+      const sorted = data.slice().sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+
+      sorted.forEach(release => {
         if (release.type === 'beta' && !showBeta) return;
         if (release.type === 'dev' && !showDev) return;
         const div = document.createElement("div");


### PR DESCRIPTION
## Summary
- ensure release list on index.html displays newest releases first

## Testing
- `python3 -m py_compile scripts/generate.py`


------
https://chatgpt.com/codex/tasks/task_e_6854b222d7bc833083eb01a6e97fd64f