### PR TITLE
Add pytest tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+      - name: Run tests
+        run: |
+          pytest -v

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,45 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import scripts.generate as generate
+
+
+def test_calculate_json_hash_deterministic():
+    data1 = {"a": 1, "b": 2}
+    data2 = {"b": 2, "a": 1}
+    hash1 = generate.calculate_json_hash(data1)
+    hash2 = generate.calculate_json_hash(data2)
+    assert hash1 == hash2
+
+
+def test_fetch_update_json_success(monkeypatch):
+    json_line = json.dumps({"version": "1.0"})
+
+    class MockResponse:
+        status_code = 200
+        text = json_line + "\nBINARYDATA"
+
+    def mock_get(url):
+        return MockResponse()
+
+    monkeypatch.setattr(generate.requests, "get", mock_get)
+    result = generate.fetch_update_json("http://example.com/update.json")
+    assert result == {"version": "1.0"}
+
+
+def test_fetch_update_json_failure(monkeypatch):
+    class MockResponse:
+        status_code = 404
+        text = ""
+
+    def mock_get(url):
+        return MockResponse()
+
+    monkeypatch.setattr(generate.requests, "get", mock_get)
+    result = generate.fetch_update_json("http://example.com/missing.json")
+    assert result is None


### PR DESCRIPTION
## Summary
- add unit tests for scripts/generate.py
- run `pytest` on PRs using GitHub Actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68559a97467083308c41ba6a9cb19a08