### PR TITLE
Update latest release path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Then execute the generator with a valid `GITHUB_TOKEN` environment variable:
 GITHUB_TOKEN=<token> python3 scripts/generate.py --owner warped-pinball --repo vector --out-dir .
 ```
 
+Latest production builds are published under a `vector/` prefix. For example,
+the System 11 firmware can be downloaded from:
+
+```
+https://software.warpedpinball.com/vector/sys11/latest.json
+```
+
 The repository includes a `CNAME` file so GitHub Pages serves the site at
 `https://updates.warpedpinball.com` without extra path segments.
 

--- a/index.html
+++ b/index.html
@@ -132,13 +132,11 @@
 
     <div id="sys11" class="tab-content active">
       <h2>System 11 Releases</h2>
-      <p><strong>Latest Release:</strong> <a href="./sys11/latest.json" target="_blank">Download latest update</a></p>
       <div id="sys11-releases" class="release-list"></div>
     </div>
 
     <div id="wpc" class="tab-content">
       <h2>WPC Releases</h2>
-      <p><strong>Latest Release:</strong> <a href="./wpc/latest.json" target="_blank">Download latest update</a></p>
       <div id="wpc-releases" class="release-list"></div>
     </div>
   </div>

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -151,7 +151,12 @@ def main():
                 "published_at": latest_release["published_at"]  # Just the date, no need for release notes
             }
 
-            latest_path = os.path.join(out_folder, "latest.json")
+            # Latest release files now live under a "vector" prefix so firmware
+            # can reference them at
+            # https://software.warpedpinball.com/vector/<product>/latest.json
+            latest_dir = os.path.join(args.out_dir, "vector", product)
+            os.makedirs(latest_dir, exist_ok=True)
+            latest_path = os.path.join(latest_dir, "latest.json")
             with open(latest_path, "w") as f:
                 json.dump(latest_release_data, f, indent=2)
             print(f"✅ Wrote {latest_path} for {product}")

--- a/vector/sys11/latest.json
+++ b/vector/sys11/latest.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.3.10",
+  "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
+  "release_page": "https://github.com/warped-pinball/vector/releases/tag/1.3.10",
+  "published_at": "2025-06-19T00:22:28+00:00"
+}

--- a/vector/wpc/latest.json
+++ b/vector/wpc/latest.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.3.10-dev83",
+  "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
+  "release_page": "https://github.com/warped-pinball/vector/releases/tag/1.3.10-dev83",
+  "published_at": "2025-06-19T02:25:50+00:00"
+}


### PR DESCRIPTION
## Summary
- generate latest.json inside a new `vector/` prefix
- remove direct latest release link from `index.html`
- document new path in README
- add `vector` folder with initial latest release files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ed83c8808330a9f6abc5ca8c2705