### PR TITLE
Fix markdown line breaks in changelog

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -142,6 +142,9 @@
   </div>
 
   <script>
+    // Render Markdown with line breaks similar to GitHub
+    marked.setOptions({ breaks: true });
+
     // Fetch the release data
     const releaseCache = {};
     let currentProduct = 'sys11';


### PR DESCRIPTION
## Summary
- ensure marked.js interprets newlines as `<br>` so GitHub style release notes render with line breaks

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867420060088330ad99fe6a37b0007e