### PR TITLE
Update sync release workflow

### DIFF
--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -38,6 +38,7 @@ jobs:
             --out-dir docs
 
       - name: Commit and push updated JSON
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           git config user.name "github-actions"
           git config user.email "actions@github.com"
@@ -45,3 +46,16 @@ jobs:
           git commit -m "Sync releases from vector @ ${{ github.run_id }}" || echo "Nothing to commit"
           # Push changes back to the same branch the workflow is running on
           git push origin HEAD:"${GITHUB_REF#refs/heads/}"
+
+      - name: Create pull request with updates
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "Sync releases from vector @ ${{ github.run_id }}"
+          title: "Sync releases from vector"
+          body: "Automated update of release metadata."
+          base: ${{ github.event.repository.default_branch }}
+          branch: sync-releases-${{ github.run_id }}
+          delete-branch: true
+          add-paths: |
+            docs/**


### PR DESCRIPTION
## Summary
- open a pull request when the sync release action is run manually
- explicitly set the base branch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872cc30e5208330b0a096f0c7eaa111