### PR TITLE
Allow manual sync with branch input

### DIFF
--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**/*.json'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the sync on'
+        required: true
+        default: main
 
 # Grant write permissions so we can commit updated JSON files
 permissions:
@@ -21,7 +27,7 @@ jobs:
       - name: Check out site repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -47,6 +53,6 @@ jobs:
           git config user.email "actions@github.com"
           git add docs
           git commit -m "Sync releases from vector @ ${{ github.run_id }}" || echo "Nothing to commit"
-          # Push changes back to the pull request branch
-          git push origin HEAD:${{ github.head_ref }}
+          # Push changes back to the appropriate branch
+          git push origin HEAD:${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
 


### PR DESCRIPTION
## Summary
- add a manual trigger for the sync-releases workflow
- allow specifying a branch when manually triggered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aab67f3f0833095bc50f3954169be