### PR TITLE
Fix incorrect latest release link

### DIFF
--- a/docs/vector/wpc/latest.json
+++ b/docs/vector/wpc/latest.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.2-beta493",
   "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-  "release_page": "https://github.com/warped-pinball/vector/releases/tag/0.0.2-beta493",
+  "release_page": "https://github.com/warped-pinball/vector/releases/tag/1.3.11-beta493",
   "notes": "## Versions\n**Vector**: `1.3.11-beta493`\n**Sys11**: `1.4.0-beta493`\n**WPC**: `0.0.2-beta493`\n**EM**: `0.0.1-beta493`\n<!-- END VERSIONS SECTION -->",
   "published_at": "2025-07-18T20:12:57+00:00"
 }

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -51,6 +51,18 @@ def parse_release_versions(text):
         versions[product] = m.group(2).strip()
     return versions
 
+
+def build_latest_release_data(owner, repo, release_entry):
+    """Return a standardized latest.json payload for a single release."""
+
+    return {
+        "version": release_entry["version"],
+        "url": release_entry["url"],
+        "release_page": f"https://github.com/{owner}/{repo}/releases/tag/{release_entry['tag']}",
+        "notes": release_entry["notes"],
+        "published_at": release_entry["published_at"],
+    }
+
 def main():
     p = argparse.ArgumentParser(
         description="Fetch releases from warped-pinball/vector and generate per-product JSON"
@@ -147,6 +159,7 @@ def main():
 
             release_entry = {
                 "version": product_version,
+                "tag": tag,
                 "url": asset.browser_download_url,
                 "notes": release.body or "No release notes provided",
                 "published_at": release.published_at.isoformat(),
@@ -182,13 +195,10 @@ def main():
                 latest_release = max(prod_releases, key=lambda r: r["published_at"])
             else:
                 latest_release = max(groups["all"], key=lambda r: r["published_at"])
-            latest_release_data = {
-                "version": latest_release["version"],
-                "url": latest_release["url"],  # This is the download link for update.json
-                "release_page": f"https://github.com/{args.owner}/{args.repo}/releases/tag/{latest_release['version']}",  # Link to the release page
-                "notes": latest_release["notes"],
-                "published_at": latest_release["published_at"]
-            }
+
+            latest_release_data = build_latest_release_data(
+                args.owner, args.repo, latest_release
+            )
 
             # Latest release metadata in the same folder
             # https://software.warpedpinball.com/vector/<product>/latest.json

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -68,3 +68,18 @@ def test_parse_release_versions_missing():
     body = "No version info"
     versions = generate.parse_release_versions(body)
     assert versions == {}
+
+
+def test_build_latest_release_data_uses_tag():
+    entry = {
+        "version": "0.0.2-beta493",
+        "tag": "1.3.11-beta493",
+        "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
+        "notes": "notes",
+        "published_at": "2025-07-18T20:12:57+00:00",
+    }
+
+    result = generate.build_latest_release_data("warped-pinball", "vector", entry)
+    assert result["release_page"].endswith("/releases/tag/1.3.11-beta493")
+    assert result["version"] == entry["version"]
+


### PR DESCRIPTION
## Summary
- fix release_page value for latest WPC release
- track release tag when generating JSON data
- add helper to build latest release metadata
- test new helper

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7b76014c83308d3bde59e879b686