### PR TITLE
Sanitize release notes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 PyGithub>=2.2.0
 requests>=2.31.0
+markdown>=3.4
+bleach>=6.0

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -68,3 +68,11 @@ def test_parse_release_versions_missing():
     body = "No version info"
     versions = generate.parse_release_versions(body)
     assert versions == {}
+
+
+def test_release_notes_to_html_sanitizes_and_strips_images():
+    md = "Hello! ![img](http://example.com/a.png) <script>alert('x')</script>"
+    html = generate.release_notes_to_html(md)
+    assert "<img" not in html
+    assert "script" not in html
+    assert "Hello" in html


### PR DESCRIPTION
## Summary
- convert GitHub release notes markdown to sanitized HTML
- strip image tags from release notes
- test new sanitization logic
- add dependencies for markdown and bleach

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7cdf1b008330948d00107c08ca1c