### PR TITLE
Fix incorrect latest release link

### DIFF
--- a/docs/builds.json
+++ b/docs/builds.json
@@ -4,1143 +4,1000 @@
     "version": "0.4.0-dev24",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "sha256": "67e95d107515f24cf32aed81ceb61462a95b802c4071e343dbd112745d9700b8",
-    "download_count": 24
+    "sha256": "67e95d107515f24cf32aed81ceb61462a95b802c4071e343dbd112745d9700b8"
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev22",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "sha256": "6eea0922fe0cb408276fd4a67f5af06e152c4960b2b421818e7fe7b3b1c905a8",
-    "download_count": 22
+    "sha256": "6eea0922fe0cb408276fd4a67f5af06e152c4960b2b421818e7fe7b3b1c905a8"
   },
   {
     "product": "sys11",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
-    "sha256": "1656ab9efbb6fac19b674088ef93550d705765590ec9bb1a79853182c5eebd34",
-    "download_count": 50
+    "sha256": "1656ab9efbb6fac19b674088ef93550d705765590ec9bb1a79853182c5eebd34"
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev25",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "sha256": "4bf1628ec5859215c70e4981e9e2c6194ca2af3869940a8431e57b093310fdc4",
-    "download_count": 20
+    "sha256": "4bf1628ec5859215c70e4981e9e2c6194ca2af3869940a8431e57b093310fdc4"
   },
   {
     "product": "sys11",
     "version": "0.3.0-beta-116",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "sha256": "94b8f41813a95bea156cb517586659d305f9e17fe63bdd068c5982b9e30284e7",
-    "download_count": 21
+    "sha256": "94b8f41813a95bea156cb517586659d305f9e17fe63bdd068c5982b9e30284e7"
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta123",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "sha256": "9795b867101152f157050055873fecfd43cdc6074a9b0c5558c712461b8bc92c",
-    "download_count": 21
+    "sha256": "9795b867101152f157050055873fecfd43cdc6074a9b0c5558c712461b8bc92c"
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta126",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "sha256": "45e650212258aff562b7807da0405803be24b4f22c4e2193d65db455d3dec809",
-    "download_count": 24
+    "sha256": "45e650212258aff562b7807da0405803be24b4f22c4e2193d65db455d3dec809"
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev28",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "sha256": "6ef072dbae58a31f9e5c1761d70c8a0648ccdac0535e239c15aca7977a08381d",
-    "download_count": 21
+    "sha256": "6ef072dbae58a31f9e5c1761d70c8a0648ccdac0535e239c15aca7977a08381d"
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "sha256": "adf1b92dd44fbeec6f3c8b03da05b66190c0b8079fd1ed0352df3b8ea3a68979",
-    "download_count": 21
+    "sha256": "adf1b92dd44fbeec6f3c8b03da05b66190c0b8079fd1ed0352df3b8ea3a68979"
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta130",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "sha256": "7abe3ea06af0a5069eaefc3156301ccf38456cfcde7c9d4da0655e6a31a207e1",
-    "download_count": 20
+    "sha256": "7abe3ea06af0a5069eaefc3156301ccf38456cfcde7c9d4da0655e6a31a207e1"
   },
   {
     "product": "sys11",
     "version": "0.4.2-dev30",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "sha256": "3ca8c984a50bc370c52c285dd6af25eacc840e43cb51c6a7cb97afcfd33a9e9c",
-    "download_count": 21
+    "sha256": "3ca8c984a50bc370c52c285dd6af25eacc840e43cb51c6a7cb97afcfd33a9e9c"
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "sha256": "bc518835ddbba8c70612247db2113a0ec77d95dfaaacad4b18dcaaf703cf61bb",
-    "download_count": 20
+    "sha256": "bc518835ddbba8c70612247db2113a0ec77d95dfaaacad4b18dcaaf703cf61bb"
   },
   {
     "product": "sys11",
     "version": "0.4.1-beta135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "sha256": "b543a43bb4748f36f660b573c14b26b68324485ce3f832fbd63e05af6d2e8083",
-    "download_count": 21
+    "sha256": "b543a43bb4748f36f660b573c14b26b68324485ce3f832fbd63e05af6d2e8083"
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev31",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "sha256": "f7f02a1f876a87ff03bd876be39ab87d0fba9b8b1d438915ea6e2064a19a8fdb",
-    "download_count": 22
+    "sha256": "f7f02a1f876a87ff03bd876be39ab87d0fba9b8b1d438915ea6e2064a19a8fdb"
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "sha256": "9a91fd6f960c57aa0ba3694f6efe9d64fa5e0225becf3efc39eb384eb7f7f8ee",
-    "download_count": 20
+    "sha256": "9a91fd6f960c57aa0ba3694f6efe9d64fa5e0225becf3efc39eb384eb7f7f8ee"
   },
   {
     "product": "sys11",
     "version": "0.4.2-beta139",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "sha256": "f9ab12742bfe30afddb9d342670932a16998cdfe0762fb49ece56cd75bd9111b",
-    "download_count": 21
+    "sha256": "f9ab12742bfe30afddb9d342670932a16998cdfe0762fb49ece56cd75bd9111b"
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev32",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "sha256": "565f94c0fd47a3709cc5ec5e1bccbc22a4e699c8cf97f4d914dc485a967a4906",
-    "download_count": 20
+    "sha256": "565f94c0fd47a3709cc5ec5e1bccbc22a4e699c8cf97f4d914dc485a967a4906"
   },
   {
     "product": "sys11",
     "version": "0.4.3-beta145",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "sha256": "82fce054a66d1a1896c808e22952b6bd61d340b4d30a4ae8f27e8a678a71f442",
-    "download_count": 21
+    "sha256": "82fce054a66d1a1896c808e22952b6bd61d340b4d30a4ae8f27e8a678a71f442"
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev35",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "sha256": "53dcb80f67fd18a90f8d6b3ea2d465dad0a8b8758fd3de97110b735e252d6ca8",
-    "download_count": 20
+    "sha256": "53dcb80f67fd18a90f8d6b3ea2d465dad0a8b8758fd3de97110b735e252d6ca8"
   },
   {
     "product": "sys11",
     "version": "0.4.5-dev33",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "sha256": "5169534401b3714b5b99e4b67226d88040f5d5205096f460deec4e59395005b8",
-    "download_count": 21
+    "sha256": "5169534401b3714b5b99e4b67226d88040f5d5205096f460deec4e59395005b8"
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev34",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "sha256": "27fa249ef5141c3e1546fb947269b7c3e44afb0bd855ce51d4fd7dea5d90f9d8",
-    "download_count": 20
+    "sha256": "27fa249ef5141c3e1546fb947269b7c3e44afb0bd855ce51d4fd7dea5d90f9d8"
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta149",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "sha256": "db152247c1426c656a405f9fa9f418a8071b4c5a40e08c0bb60119631ce0ecd7",
-    "download_count": 21
+    "sha256": "db152247c1426c656a405f9fa9f418a8071b4c5a40e08c0bb60119631ce0ecd7"
   },
   {
     "product": "sys11",
     "version": "0.4.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
-    "sha256": "376459549328da0d9901d09d5eb1a3104c0342050884d6f792432dc6e7ff1def",
-    "download_count": 21
+    "sha256": "376459549328da0d9901d09d5eb1a3104c0342050884d6f792432dc6e7ff1def"
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "sha256": "34edbcc682cc836ef0542f20e57e459af750e4dcddfdcbef56c60641d9221968",
-    "download_count": 21
+    "sha256": "34edbcc682cc836ef0542f20e57e459af750e4dcddfdcbef56c60641d9221968"
   },
   {
     "product": "sys11",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
-    "sha256": "2b0cf6a267990bdae5bff16d04e5938b5b9251edf025e95b75139d4d714d96fa",
-    "download_count": 35
+    "sha256": "2b0cf6a267990bdae5bff16d04e5938b5b9251edf025e95b75139d4d714d96fa"
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev43",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "sha256": "4179f70bb31147276d5612f770e1e9db84c4323459f76ae10c2ac80cb578c488",
-    "download_count": 20
+    "sha256": "4179f70bb31147276d5612f770e1e9db84c4323459f76ae10c2ac80cb578c488"
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta203",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "sha256": "9507526dedfd0f22c2e123b756f183e49e69003ee3fd73e553f6c4b0aaa442d2",
-    "download_count": 20
+    "sha256": "9507526dedfd0f22c2e123b756f183e49e69003ee3fd73e553f6c4b0aaa442d2"
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev45",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "sha256": "088c4801f058d95d6767fa0d5a21a8ea51e7caed4067cff9656e3a0d06ec6cbd",
-    "download_count": 20
+    "sha256": "088c4801f058d95d6767fa0d5a21a8ea51e7caed4067cff9656e3a0d06ec6cbd"
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "sha256": "019b6c20a9f3b0a8ed5d09d620529e47081d5ed32ada892b1fcef007312b77e8",
-    "download_count": 20
+    "sha256": "019b6c20a9f3b0a8ed5d09d620529e47081d5ed32ada892b1fcef007312b77e8"
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev46",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "sha256": "5f2e55425adc9f354eb1979a8270c675ead97ca491460b0d2d19851e6e9b67cf",
-    "download_count": 25
+    "sha256": "5f2e55425adc9f354eb1979a8270c675ead97ca491460b0d2d19851e6e9b67cf"
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev44",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "sha256": "a58774cf70263ed7aa91f8d9e25e3283381b98814087a852f90fecebb9f39154",
-    "download_count": 20
+    "sha256": "a58774cf70263ed7aa91f8d9e25e3283381b98814087a852f90fecebb9f39154"
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta211",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "sha256": "11eb8e7743dc7296ee763f01076f55920465a8141b5cf4056a282d08f24c6a6b",
-    "download_count": 20
+    "sha256": "11eb8e7743dc7296ee763f01076f55920465a8141b5cf4056a282d08f24c6a6b"
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta225",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "sha256": "487cbba52e242e895022b5b96f27894438ffc28e3953b068e59ae7ba9e5cc6d1",
-    "download_count": 20
+    "sha256": "487cbba52e242e895022b5b96f27894438ffc28e3953b068e59ae7ba9e5cc6d1"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "sha256": "863c871003253953b04c0c340fc91e7a13069816be45954290ebadbcb784dc89",
-    "download_count": 23
+    "sha256": "863c871003253953b04c0c340fc91e7a13069816be45954290ebadbcb784dc89"
   },
   {
     "product": "sys11",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
-    "sha256": "1b3862c944feae7daafcefdbdebd69be4a1bfb09add5fb707e9fc387541e742f",
-    "download_count": 22
+    "sha256": "1b3862c944feae7daafcefdbdebd69be4a1bfb09add5fb707e9fc387541e742f"
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "sha256": "fd1165452e835ad94ef678941f84662a7f5c830489c98f8cc38ca62a5e56faff",
-    "download_count": 20
+    "sha256": "fd1165452e835ad94ef678941f84662a7f5c830489c98f8cc38ca62a5e56faff"
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "sha256": "8e2ea2f5da26d3cc542ece96735a93b209e1a32c2759ade31d503b7e5546822c",
-    "download_count": 20
+    "sha256": "8e2ea2f5da26d3cc542ece96735a93b209e1a32c2759ade31d503b7e5546822c"
   },
   {
     "product": "sys11",
     "version": "1.1.0-beta227",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "sha256": "230cd88bc67ef84ad8b7e5006f23d266a4e5ce5f7b93c80e0a661878a4bdd9a0",
-    "download_count": 22
+    "sha256": "230cd88bc67ef84ad8b7e5006f23d266a4e5ce5f7b93c80e0a661878a4bdd9a0"
   },
   {
     "product": "sys11",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
-    "sha256": "e4cdfcb01b26417b826deb51265375c4c858a8068c424c2c3459db0a687d96c3",
-    "download_count": 25
+    "sha256": "e4cdfcb01b26417b826deb51265375c4c858a8068c424c2c3459db0a687d96c3"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "sha256": "727990fa3a7c9d8d98101ea2bed660c6b2e7755e1471c9cfa46d22322ea1bf7c",
-    "download_count": 20
+    "sha256": "727990fa3a7c9d8d98101ea2bed660c6b2e7755e1471c9cfa46d22322ea1bf7c"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "sha256": "80351166b7e98a24cdfe519da5bb89840a829067ecd826726df83ef5cbfcbe84",
-    "download_count": 20
+    "sha256": "80351166b7e98a24cdfe519da5bb89840a829067ecd826726df83ef5cbfcbe84"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev51",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "sha256": "d6847aee1fd42a6f667094c2ad1fdad9434388ff005448e1202a0eb514a276a2",
-    "download_count": 20
+    "sha256": "d6847aee1fd42a6f667094c2ad1fdad9434388ff005448e1202a0eb514a276a2"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev50",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "sha256": "23fb0dfc452019d9fbd2e2c1f69c11ee8e8fe11568826a806bb4be4ca1aa5d07",
-    "download_count": 20
+    "sha256": "23fb0dfc452019d9fbd2e2c1f69c11ee8e8fe11568826a806bb4be4ca1aa5d07"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "sha256": "b014089add563a6214dfa775c222d95bcb7ebe99c87b14dfb96e06081ae00e3e",
-    "download_count": 20
+    "sha256": "b014089add563a6214dfa775c222d95bcb7ebe99c87b14dfb96e06081ae00e3e"
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "sha256": "97e31ff6583ec703524c302a4e07d8cdf8530d1c8b76ea16f1bd2763a3a243ac",
-    "download_count": 20
+    "sha256": "97e31ff6583ec703524c302a4e07d8cdf8530d1c8b76ea16f1bd2763a3a243ac"
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta235",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "sha256": "b8c489c01178f82e2af42e8c8d1b935a807b88fc60bc09a55cd4839f2a4d6da8",
-    "download_count": 20
+    "sha256": "b8c489c01178f82e2af42e8c8d1b935a807b88fc60bc09a55cd4839f2a4d6da8"
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta246",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "sha256": "1eb18f482a66311c8792b86997fc29cab809327a196c28e5acabf2eacd0b1d0f",
-    "download_count": 20
+    "sha256": "1eb18f482a66311c8792b86997fc29cab809327a196c28e5acabf2eacd0b1d0f"
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "sha256": "fb938be791735fe189b018a0e245bf9e347f28f5146a1a58b0978cfacd3cb2d9",
-    "download_count": 20
+    "sha256": "fb938be791735fe189b018a0e245bf9e347f28f5146a1a58b0978cfacd3cb2d9"
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta251",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "sha256": "6db287b76e714d111f926e6afb3039dc34fcd9f838d34825907cddcb0f499af0",
-    "download_count": 20
+    "sha256": "6db287b76e714d111f926e6afb3039dc34fcd9f838d34825907cddcb0f499af0"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "sha256": "d0ce844de906af3b2cda5243744f8cf56d666b6dbcfa530d36d0598ad9d9fe13",
-    "download_count": 20
+    "sha256": "d0ce844de906af3b2cda5243744f8cf56d666b6dbcfa530d36d0598ad9d9fe13"
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta254",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "sha256": "634048d550bf476ec25a7034dfcca5ba2a6665489a33d24cc1c39e4befba0bc4",
-    "download_count": 20
+    "sha256": "634048d550bf476ec25a7034dfcca5ba2a6665489a33d24cc1c39e4befba0bc4"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "sha256": "598924c028a4f41e657a2903d45d86b63ae0354ab9d13d3f4157cafc42daba7e",
-    "download_count": 20
+    "sha256": "598924c028a4f41e657a2903d45d86b63ae0354ab9d13d3f4157cafc42daba7e"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev54",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "sha256": "1630797d86357070d0d27341015fab15f592ece54a37cf0aa3f26f6d3ca3533e",
-    "download_count": 20
+    "sha256": "1630797d86357070d0d27341015fab15f592ece54a37cf0aa3f26f6d3ca3533e"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "sha256": "0b99528c4fc5138b56d9e658d6062c05fd30997562a72d57aac4a7050bf9c299",
-    "download_count": 20
+    "sha256": "0b99528c4fc5138b56d9e658d6062c05fd30997562a72d57aac4a7050bf9c299"
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta258",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "sha256": "20b4292203a9db6c4e95a8ff2a2b18cd4cf84fe8daf5229061c59025d4d79655",
-    "download_count": 20
+    "sha256": "20b4292203a9db6c4e95a8ff2a2b18cd4cf84fe8daf5229061c59025d4d79655"
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "sha256": "fcfc5d710bba8f9ca0a95f13184e9b40c98d8f46a7528e01e849e05e1c28f57b",
-    "download_count": 20
+    "sha256": "fcfc5d710bba8f9ca0a95f13184e9b40c98d8f46a7528e01e849e05e1c28f57b"
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "sha256": "0d7cba21ab9e809c679bd57f7ab07146f3db5a9922ebb7cdd65ce9b06d570738",
-    "download_count": 21
+    "sha256": "0d7cba21ab9e809c679bd57f7ab07146f3db5a9922ebb7cdd65ce9b06d570738"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "sha256": "10a3d7f2b5752e4d34b33c6c0b85c67bb13b64b9f5b8c596f34ba3178d7528dd",
-    "download_count": 20
+    "sha256": "10a3d7f2b5752e4d34b33c6c0b85c67bb13b64b9f5b8c596f34ba3178d7528dd"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev57",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "sha256": "2b5fdadd67d5324fd8c8ff455063d113bbb9fd99bcd8050436e9ef9d383f3ebc",
-    "download_count": 20
+    "sha256": "2b5fdadd67d5324fd8c8ff455063d113bbb9fd99bcd8050436e9ef9d383f3ebc"
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "sha256": "23d859353f3e141ca206e993ca4bdf2f9b7505e3a596f7ca6ff9487af26e1751",
-    "download_count": 20
+    "sha256": "23d859353f3e141ca206e993ca4bdf2f9b7505e3a596f7ca6ff9487af26e1751"
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "sha256": "2765033c0235e456c9eabfb30ebab3ef8eca8dc02b16e15c95784d27f34ed561",
-    "download_count": 20
+    "sha256": "2765033c0235e456c9eabfb30ebab3ef8eca8dc02b16e15c95784d27f34ed561"
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev61",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "sha256": "67fda10bddb7d1bf5fa9f16b10c3b2f9359b0a4a491c6fa2c747a6386a04ec00",
-    "download_count": 20
+    "sha256": "67fda10bddb7d1bf5fa9f16b10c3b2f9359b0a4a491c6fa2c747a6386a04ec00"
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "sha256": "4c3db39f48f7e18f9e7a4d9ed3b6459e38bc4799a98060df3766493d544e6b45",
-    "download_count": 20
+    "sha256": "4c3db39f48f7e18f9e7a4d9ed3b6459e38bc4799a98060df3766493d544e6b45"
   },
   {
     "product": "sys11",
     "version": "1.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
-    "sha256": "2c5224e43ee9a51ae9369f472302e82216b2efbced0775fea787dd6e689b3b42",
-    "download_count": 21
+    "sha256": "2c5224e43ee9a51ae9369f472302e82216b2efbced0775fea787dd6e689b3b42"
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "sha256": "442fb92d5bf1647b694417600b967fe5525c78fb23a5cf20c59df28d4a803419",
-    "download_count": 24
+    "sha256": "442fb92d5bf1647b694417600b967fe5525c78fb23a5cf20c59df28d4a803419"
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "sha256": "273ce7a481b8df18eb6db14c81c33562af8d61efa6afc2c75a64aeb07e50f575",
-    "download_count": 20
+    "sha256": "273ce7a481b8df18eb6db14c81c33562af8d61efa6afc2c75a64aeb07e50f575"
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "sha256": "b4db35985dee7a2eae682dfc2c27ddd30b87a94c3ed66cb1f6076aed437ebe48",
-    "download_count": 20
+    "sha256": "b4db35985dee7a2eae682dfc2c27ddd30b87a94c3ed66cb1f6076aed437ebe48"
   },
   {
     "product": "sys11",
     "version": "1.3.1-beta310",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "sha256": "447d81e010f5bccdb2d8706afaa90e99923d9d421fe4c92f81fefbb0324dc9e8",
-    "download_count": 20
+    "sha256": "447d81e010f5bccdb2d8706afaa90e99923d9d421fe4c92f81fefbb0324dc9e8"
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "sha256": "4f6e4f4a132e5993d62e7ee9fe80ee5e72ac50386d4e293bbc19112ec815760e",
-    "download_count": 20
+    "sha256": "4f6e4f4a132e5993d62e7ee9fe80ee5e72ac50386d4e293bbc19112ec815760e"
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "sha256": "57f3290a2789ff4d48cbcca6ec4c61a8bfad3f0657fe6ff4f7a36e07396e943a",
-    "download_count": 20
+    "sha256": "57f3290a2789ff4d48cbcca6ec4c61a8bfad3f0657fe6ff4f7a36e07396e943a"
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta320",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "sha256": "f357984c81920c7c8d1a81e29edd0ccef16c235388d327547c923456bdaf3f87",
-    "download_count": 20
+    "sha256": "f357984c81920c7c8d1a81e29edd0ccef16c235388d327547c923456bdaf3f87"
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta319",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "sha256": "1965cc9c0fa070752193e8693797d1e1c3ad3e8a3ead1458f0c83859acda4bc6",
-    "download_count": 20
+    "sha256": "1965cc9c0fa070752193e8693797d1e1c3ad3e8a3ead1458f0c83859acda4bc6"
   },
   {
     "product": "sys11",
     "version": "1.3.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
-    "sha256": "98d94524b525c7a111e5ebbbb1515fbb966ffdc8d0dddde9f28c171c3befb5c8",
-    "download_count": 22
+    "sha256": "98d94524b525c7a111e5ebbbb1515fbb966ffdc8d0dddde9f28c171c3befb5c8"
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev62",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "sha256": "f62a6a76250180a33256a8896e2fc7c7a9301638405009cfbb16141c5255463b",
-    "download_count": 20
+    "sha256": "f62a6a76250180a33256a8896e2fc7c7a9301638405009cfbb16141c5255463b"
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta324",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "sha256": "4394c655205483f6f79d6a4ffa5103b685692a4ea743353ea473533681202605",
-    "download_count": 20
+    "sha256": "4394c655205483f6f79d6a4ffa5103b685692a4ea743353ea473533681202605"
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta327",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "sha256": "4a393ac80ef52c8dd28ff74d08f3716741f3d861e1ea0cd944e99e5790b4279f",
-    "download_count": 20
+    "sha256": "4a393ac80ef52c8dd28ff74d08f3716741f3d861e1ea0cd944e99e5790b4279f"
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "sha256": "78f5292ac105f0a51f7a8e83fdfed8629a768d54b8e39af880ad0f4ff524c08d",
-    "download_count": 20
+    "sha256": "78f5292ac105f0a51f7a8e83fdfed8629a768d54b8e39af880ad0f4ff524c08d"
   },
   {
     "product": "sys11",
     "version": "1.3.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
-    "sha256": "3175cce0e8c5df8e342f00737dec2692ba8e4730b6a10e87b6455077f2df853a",
-    "download_count": 31
+    "sha256": "3175cce0e8c5df8e342f00737dec2692ba8e4730b6a10e87b6455077f2df853a"
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "sha256": "23b5e0918a6dc7a50bd86fd52a3d867f62b5c88254af570abc8aca4101e56796",
-    "download_count": 20
+    "sha256": "23b5e0918a6dc7a50bd86fd52a3d867f62b5c88254af570abc8aca4101e56796"
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev63",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "sha256": "012ee792adbf4fee2347a9a448f41c0a0d2883c73c02f15679872937bfc2de3a",
-    "download_count": 20
+    "sha256": "012ee792adbf4fee2347a9a448f41c0a0d2883c73c02f15679872937bfc2de3a"
   },
   {
     "product": "sys11",
     "version": "1.3.3-beta330",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "sha256": "b7b4ceef32900fee06bb92481c61d45d56d9c0f74b2ddd1e7bd18282722b9bb6",
-    "download_count": 20
+    "sha256": "b7b4ceef32900fee06bb92481c61d45d56d9c0f74b2ddd1e7bd18282722b9bb6"
   },
   {
     "product": "sys11",
     "version": "1.3.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
-    "sha256": "9bf829deeeb8a5fd4b4e1d3e7ad4188e9a3c84b5e9fea522123d3e2419a7982c",
-    "download_count": 31
+    "sha256": "9bf829deeeb8a5fd4b4e1d3e7ad4188e9a3c84b5e9fea522123d3e2419a7982c"
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "sha256": "17ffdaf762d2197f53bd3992f1e618f321833384b283ccd7f7804ce322e1d7f3",
-    "download_count": 20
+    "sha256": "17ffdaf762d2197f53bd3992f1e618f321833384b283ccd7f7804ce322e1d7f3"
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "sha256": "309edc0f7965862e0be8721e1240a3fe3e4474297258425a11ce29a64d0ca8d8",
-    "download_count": 20
+    "sha256": "309edc0f7965862e0be8721e1240a3fe3e4474297258425a11ce29a64d0ca8d8"
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev66",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "sha256": "d3e204caddef063d9d104c5e7eda9e876b3e9761abd577ce909b0d5e95116147",
-    "download_count": 20
+    "sha256": "d3e204caddef063d9d104c5e7eda9e876b3e9761abd577ce909b0d5e95116147"
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev65",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "sha256": "2a13dcc4bc28e4d672a1f9295d61473f21ad5c143114db4a3494df46f355caed",
-    "download_count": 21
+    "sha256": "2a13dcc4bc28e4d672a1f9295d61473f21ad5c143114db4a3494df46f355caed"
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta338",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "sha256": "6c056aa34f4dbd500cce6075ff88b7cc1dc93a0d2e1e9d264e257b403558179d",
-    "download_count": 20
+    "sha256": "6c056aa34f4dbd500cce6075ff88b7cc1dc93a0d2e1e9d264e257b403558179d"
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev70",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
-    "sha256": "fb15ef1568b9a4175a7459cee0c6f61713ca70f577c31d293bd6fc4a218a40c8",
-    "download_count": 20
+    "sha256": "fb15ef1568b9a4175a7459cee0c6f61713ca70f577c31d293bd6fc4a218a40c8"
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta358",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
-    "sha256": "4c8f7a690f04615f793845fff89f7a5e5f2dffe57cdca9eb4ec10d08a22411a2",
-    "download_count": 20
+    "sha256": "4c8f7a690f04615f793845fff89f7a5e5f2dffe57cdca9eb4ec10d08a22411a2"
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "sha256": "a2be8d0fdc30cdfc7dc627c7f5ef48e838f94fa71adc33eea61febcadaae0dda",
-    "download_count": 20
+    "sha256": "a2be8d0fdc30cdfc7dc627c7f5ef48e838f94fa71adc33eea61febcadaae0dda"
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta361",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "sha256": "6a81a0787f6d38be9fd0395458193be106006f07e9ab19f0b105db027426006b",
-    "download_count": 20
+    "sha256": "6a81a0787f6d38be9fd0395458193be106006f07e9ab19f0b105db027426006b"
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "sha256": "a21bb6d10b85341e68a4b1b7210a47fc383315abbca8789a5f56158701cee0fd",
-    "download_count": 20
+    "sha256": "a21bb6d10b85341e68a4b1b7210a47fc383315abbca8789a5f56158701cee0fd"
   },
   {
     "product": "sys11",
     "version": "1.3.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
-    "sha256": "4095cad8eb9800cfd08016618dfe6861e59f464dd9376ad856d1b3d8aeb486df",
-    "download_count": 192
+    "sha256": "4095cad8eb9800cfd08016618dfe6861e59f464dd9376ad856d1b3d8aeb486df"
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "sha256": "1c26ecc8c15519a2143144cdc5841d5ce4c8f7eb2eec986398369a3c5c7a1109",
-    "download_count": 20
+    "sha256": "1c26ecc8c15519a2143144cdc5841d5ce4c8f7eb2eec986398369a3c5c7a1109"
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta363",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "sha256": "1ffbf884249ca0a94c1ea932c47f29a4c93064b124e79ed44ea92ee5b7a8037d",
-    "download_count": 20
+    "sha256": "1ffbf884249ca0a94c1ea932c47f29a4c93064b124e79ed44ea92ee5b7a8037d"
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "sha256": "d6ee309461f8a7dd899ae9da60596c6180d4100b0ba248598f9bde379b46a1e8",
-    "download_count": 20
+    "sha256": "d6ee309461f8a7dd899ae9da60596c6180d4100b0ba248598f9bde379b46a1e8"
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta372",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "sha256": "aba2e3d5b03f8064e7dcf09c0148baa2e67de71cb3293ac6738ca23b3abb05a2",
-    "download_count": 20
+    "sha256": "aba2e3d5b03f8064e7dcf09c0148baa2e67de71cb3293ac6738ca23b3abb05a2"
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta376",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "sha256": "6d8ca3ad8e7bc5be16bc38a39576606454eefff28e9aab3303407e69934f8404",
-    "download_count": 21
+    "sha256": "6d8ca3ad8e7bc5be16bc38a39576606454eefff28e9aab3303407e69934f8404"
   },
   {
     "product": "sys11",
     "version": "1.3.7-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "sha256": "eab166e2504f138ce3934ed07c40bd6f60bacefe3992c2b6e504d9e2cd24b6b7",
-    "download_count": 21
+    "sha256": "eab166e2504f138ce3934ed07c40bd6f60bacefe3992c2b6e504d9e2cd24b6b7"
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "sha256": "9873cf75f964d89a63bc0a646d7e4ae827183a0a4c06a975c2172e9dabde007b",
-    "download_count": 21
+    "sha256": "9873cf75f964d89a63bc0a646d7e4ae827183a0a4c06a975c2172e9dabde007b"
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "sha256": "f4e5ebbf2900b4a9b33ca361cbd5cbd74520f2e2329d57327797c3615f4994d7",
-    "download_count": 21
+    "sha256": "f4e5ebbf2900b4a9b33ca361cbd5cbd74520f2e2329d57327797c3615f4994d7"
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta378",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "sha256": "fd37bc9c0369addfe81760bd1b54884e68c5db7710c5375a0c4e680b12cafda1",
-    "download_count": 21
+    "sha256": "fd37bc9c0369addfe81760bd1b54884e68c5db7710c5375a0c4e680b12cafda1"
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev74",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "sha256": "39b87d2cc1119f5f7283fb35e78baa6989ef1cde272c8d128f8cc636e717da0f",
-    "download_count": 23
+    "sha256": "39b87d2cc1119f5f7283fb35e78baa6989ef1cde272c8d128f8cc636e717da0f"
   },
   {
     "product": "sys11",
     "version": "1.3.7",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
-    "sha256": "ab11a476a06a7b3a9217b430b61c78ba7b202fdefa2f19979ff24fd34ca0bf45",
-    "download_count": 141
+    "sha256": "ab11a476a06a7b3a9217b430b61c78ba7b202fdefa2f19979ff24fd34ca0bf45"
   },
   {
     "product": "sys11",
     "version": "1.3.7-beta381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "sha256": "0b783a46455071204289f537336eb4a96773ca1f8d5823cb7de5aa9d51668f08",
-    "download_count": 22
+    "sha256": "0b783a46455071204289f537336eb4a96773ca1f8d5823cb7de5aa9d51668f08"
   },
   {
     "product": "sys11",
     "version": "1.3.8",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
-    "sha256": "3c5b9a7482302cdcfa8094db05eb05b874574ab482103875997ac56de4b2ab7d",
-    "download_count": 41
+    "sha256": "3c5b9a7482302cdcfa8094db05eb05b874574ab482103875997ac56de4b2ab7d"
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev78",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "sha256": "34e6ae58696b2b9fa0cfd2c81087df1304ce713dffe1b01eb3ea2907a89f2418",
-    "download_count": 21
+    "sha256": "34e6ae58696b2b9fa0cfd2c81087df1304ce713dffe1b01eb3ea2907a89f2418"
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev77",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "sha256": "c495a08af8af45e688eeca719d2839ef034e6d8c713b841180ec771cd14b26a7",
-    "download_count": 20
+    "sha256": "c495a08af8af45e688eeca719d2839ef034e6d8c713b841180ec771cd14b26a7"
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev76",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "sha256": "3724e6fb8d07794f627b6d8f4275b653ce70a6d9b2cdf876bc6b04da18204358",
-    "download_count": 23
+    "sha256": "3724e6fb8d07794f627b6d8f4275b653ce70a6d9b2cdf876bc6b04da18204358"
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta386",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "sha256": "3378edb818ad4bffd4ae9c4f4ce737f92d9158e36b9d98b14ce2ebb011043fd3",
-    "download_count": 21
+    "sha256": "3378edb818ad4bffd4ae9c4f4ce737f92d9158e36b9d98b14ce2ebb011043fd3"
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta394",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "sha256": "0a4b92b76db6b5cc17ababe1bf60bd98773ee1ff57e5e4fa627d59c8c62f95b4",
-    "download_count": 21
+    "sha256": "0a4b92b76db6b5cc17ababe1bf60bd98773ee1ff57e5e4fa627d59c8c62f95b4"
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev80",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "sha256": "1c94ba30cceba7a0090206d6d3a4ca22f9f31aefda61d8ae366504d4b6f324e2",
-    "download_count": 24
+    "sha256": "1c94ba30cceba7a0090206d6d3a4ca22f9f31aefda61d8ae366504d4b6f324e2"
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta396",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "sha256": "c24faa005fda7db4676f460a7c64aa67997acb9201ce594390672dd94ad1eb13",
-    "download_count": 21
+    "sha256": "c24faa005fda7db4676f460a7c64aa67997acb9201ce594390672dd94ad1eb13"
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev81",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "sha256": "2210d8aea7c213e18379eb09ab75985aeac317bc2c672a179204504fe47d54e7",
-    "download_count": 21
+    "sha256": "2210d8aea7c213e18379eb09ab75985aeac317bc2c672a179204504fe47d54e7"
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta399",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "sha256": "e86454d786dcc1fdbf2af01c56108d06e7ac8503e33d33cda7763f9459deb68b",
-    "download_count": 21
+    "sha256": "e86454d786dcc1fdbf2af01c56108d06e7ac8503e33d33cda7763f9459deb68b"
   },
   {
     "product": "sys11",
     "version": "1.3.9",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
-    "sha256": "984873bfefc677ccfb0d0524e13ca46b000c395653391335e58244aa6f8a3ee0",
-    "download_count": 42
+    "sha256": "984873bfefc677ccfb0d0524e13ca46b000c395653391335e58244aa6f8a3ee0"
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev82",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "sha256": "a2cc3968a4301f0fae4dbb50742f90b0fcd4b079424df6226bacfbebd776747a",
-    "download_count": 20
+    "sha256": "a2cc3968a4301f0fae4dbb50742f90b0fcd4b079424df6226bacfbebd776747a"
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta404",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "sha256": "b308604f0b7b2397ca32efffa911aa2f45f30efd6276e4dec629ad531ec4961d",
-    "download_count": 21
+    "sha256": "b308604f0b7b2397ca32efffa911aa2f45f30efd6276e4dec629ad531ec4961d"
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "sha256": "b7c4cc328091bcc20dfa1201afc05b91e09489feb8788e5e9739a47c841cddb0",
-    "download_count": 19
+    "sha256": "b7c4cc328091bcc20dfa1201afc05b91e09489feb8788e5e9739a47c841cddb0"
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "sha256": "ac959a4710ee625b570153c5a928b5bb348ceff99ae73bd9eb179e59102792ae",
-    "download_count": 19
+    "sha256": "ac959a4710ee625b570153c5a928b5bb348ceff99ae73bd9eb179e59102792ae"
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta408",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "sha256": "ff7f10b3522a3260a52085913a403fe32e49acd4ef1e8c283e56b1ca6d3d2bb5",
-    "download_count": 20
+    "sha256": "ff7f10b3522a3260a52085913a403fe32e49acd4ef1e8c283e56b1ca6d3d2bb5"
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "sha256": "c22d47a3c2032c899f516a6793722ac79051bb748ffbecc9e021b3685a754213",
-    "download_count": 5
+    "sha256": "c22d47a3c2032c899f516a6793722ac79051bb748ffbecc9e021b3685a754213"
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "sha256": "16a2d3eda99bb8d3e966990cb24082bcdc9728010a0cbfffaea50ec0ea772388",
-    "download_count": 5
+    "sha256": "16a2d3eda99bb8d3e966990cb24082bcdc9728010a0cbfffaea50ec0ea772388"
   },
   {
     "product": "sys11",
     "version": "1.3.10",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
-    "sha256": "e5d90ca6716395a4b1fe0371475eb661aded254c4b53749ac91aa8ec5761373a",
-    "download_count": 35
+    "sha256": "e5d90ca6716395a4b1fe0371475eb661aded254c4b53749ac91aa8ec5761373a"
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "sha256": "1d70a872c9f8689bb171a3ffda2c464b5e57e9994eac904594f63f27098e40b1",
-    "download_count": 15
+    "sha256": "1d70a872c9f8689bb171a3ffda2c464b5e57e9994eac904594f63f27098e40b1"
   },
   {
     "product": "wpc",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "sha256": "1d70a872c9f8689bb171a3ffda2c464b5e57e9994eac904594f63f27098e40b1",
-    "download_count": 15
+    "sha256": "1d70a872c9f8689bb171a3ffda2c464b5e57e9994eac904594f63f27098e40b1"
   },
   {
     "product": "sys11",
     "version": "1.3.10-beta419",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "sha256": "4a25ccaa50b7ada4fd49578dc21e35c0d60f3ae2b83a0e8122b2e17ebc9a1776",
-    "download_count": 19
+    "sha256": "4a25ccaa50b7ada4fd49578dc21e35c0d60f3ae2b83a0e8122b2e17ebc9a1776"
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "sha256": "c66dda49c9cca405f97bddcd8058d293d3c8aa90a5d2894e45d24339705195f4",
-    "download_count": 5
+    "sha256": "c66dda49c9cca405f97bddcd8058d293d3c8aa90a5d2894e45d24339705195f4"
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "sha256": "6a7592ccfa4f94bf625d0a77e7b0090c72acd46456cfd785571e2005d2cb6d4a",
-    "download_count": 5
+    "sha256": "6a7592ccfa4f94bf625d0a77e7b0090c72acd46456cfd785571e2005d2cb6d4a"
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "sha256": "85261ea2852ef759811d24f48491164e9d8399e85e9201406a8fbf0ffed7c39f",
-    "download_count": 5
+    "sha256": "85261ea2852ef759811d24f48491164e9d8399e85e9201406a8fbf0ffed7c39f"
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "sha256": "9310db56abbb9248166438c4600aaba94df944874a8a7f8ffe10f3a2f0bf549b",
-    "download_count": 4
+    "sha256": "9310db56abbb9248166438c4600aaba94df944874a8a7f8ffe10f3a2f0bf549b"
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "sha256": "4b52cf3596911b3d588a9cf8472c00f8d35bd3fa028be17d8a24e627b97f0575",
-    "download_count": 3
+    "sha256": "4b52cf3596911b3d588a9cf8472c00f8d35bd3fa028be17d8a24e627b97f0575"
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "sha256": "87be740d61d3d492c82daae5962184414036e1c9c54bf46a0c1dd3b93df764cf",
-    "download_count": 3
+    "sha256": "87be740d61d3d492c82daae5962184414036e1c9c54bf46a0c1dd3b93df764cf"
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "sha256": "88651381ab4340440140763006b0b558f1e613f1f9ad0c2297ad77c6b6728e66",
-    "download_count": 3
+    "sha256": "88651381ab4340440140763006b0b558f1e613f1f9ad0c2297ad77c6b6728e66"
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "sha256": "a94458c46124a2836a7a9ec33044c2e8d45f57b0bc6921f3400765ff48eb8cc2",
-    "download_count": 3
+    "sha256": "a94458c46124a2836a7a9ec33044c2e8d45f57b0bc6921f3400765ff48eb8cc2"
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "sha256": "6e1cce0eb99ea599246b8b9eb8a9aa7971239a7437565ea8b7f0fdefa2192e81",
-    "download_count": 3
+    "sha256": "6e1cce0eb99ea599246b8b9eb8a9aa7971239a7437565ea8b7f0fdefa2192e81"
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "sha256": "0abd8129c774f095d1c9aeb53151d75cea3a3e2671b3e6df326259dc2e81b6b6",
-    "download_count": 3
+    "sha256": "0abd8129c774f095d1c9aeb53151d75cea3a3e2671b3e6df326259dc2e81b6b6"
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "sha256": "ce64d5b3a1a951207ec49569873d9d5decd6bb5ba8cab3c9008e974d18885166",
-    "download_count": 0
+    "sha256": "ce64d5b3a1a951207ec49569873d9d5decd6bb5ba8cab3c9008e974d18885166"
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "sha256": "d0a2fb2adbb105a74a24bf8a09b591b105cb2fea00f16cd7134b71add7734977",
-    "download_count": 0
+    "sha256": "d0a2fb2adbb105a74a24bf8a09b591b105cb2fea00f16cd7134b71add7734977"
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "sha256": "75b93135c9478d3dcf01858c6457d4adc614967ef4bac437ac14b2e63ef44095",
-    "download_count": 3
+    "sha256": "75b93135c9478d3dcf01858c6457d4adc614967ef4bac437ac14b2e63ef44095"
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "sha256": "66105183d0d1f94fc79c758526c5bac1466a2477d17e52bbe179b2d6090e2bd7",
-    "download_count": 3
+    "sha256": "66105183d0d1f94fc79c758526c5bac1466a2477d17e52bbe179b2d6090e2bd7"
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "sha256": "ca69f718286eef561897449d892c667bd5f3954cee5b4c1a0b4de865e95c0674",
-    "download_count": 0
+    "sha256": "ca69f718286eef561897449d892c667bd5f3954cee5b4c1a0b4de865e95c0674"
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "sha256": "69519b1cb981691005bd0b5b132474e91619403d991fc8fae0772de9a8bdfef7",
-    "download_count": 0
+    "sha256": "69519b1cb981691005bd0b5b132474e91619403d991fc8fae0772de9a8bdfef7"
   }
 ]

--- a/docs/download_counts.json
+++ b/docs/download_counts.json
@@ -1,0 +1,3005 @@
+[
+  {
+    "product": "sys11",
+    "version": "0.4.0-dev24",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
+    "download_count": 24
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.0-dev22",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
+    "download_count": 22
+  },
+  {
+    "product": "sys11",
+    "version": "0.3.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
+    "download_count": 50
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.0-dev25",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.3.0-beta-116",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.0-beta123",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.0-beta126",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
+    "download_count": 24
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.1-dev28",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.0-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.0-beta130",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.2-dev30",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.1-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.1-beta135",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.3-dev31",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
+    "download_count": 22
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.3-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.2-beta139",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.4-dev32",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.3-beta145",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-dev35",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.5-dev33",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.4-dev34",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.4-beta149",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.4",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "0.4.4-beta160",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
+    "download_count": 35
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-dev43",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-beta203",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.1.0-dev45",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-dev47",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-dev46",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
+    "download_count": 25
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-dev44",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-beta211",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.0.0-beta225",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev47",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
+    "download_count": 23
+  },
+  {
+    "product": "sys11",
+    "version": "1.1.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
+    "download_count": 22
+  },
+  {
+    "product": "sys11",
+    "version": "1.1.0-dev49",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.1.0-dev48",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.1.0-beta227",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
+    "download_count": 22
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
+    "download_count": 25
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev52",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev51",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev50",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev49",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-dev48",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-beta235",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-beta246",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-beta247",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-beta251",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev52",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.2.0-beta254",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev55",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev54",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-beta258",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1-dev58",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1-dev55",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev59",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev57",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-dev56",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.0-beta262",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-dev61",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-dev60",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1-dev60",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
+    "download_count": 24
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1-dev59",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1-dev56",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.1-beta310",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-dev58",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-beta320",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-beta319",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
+    "download_count": 22
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-dev62",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-beta324",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.2-beta327",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-dev64",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.3",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
+    "download_count": 31
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.3-dev64",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.3-dev63",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.3-beta330",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
+    "download_count": 31
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-dev67",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-dev66",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-dev65",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-beta338",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-dev70",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-beta358",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-dev67",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-beta361",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.6-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
+    "download_count": 192
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-beta363",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-dev72",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.5-beta372",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.6-beta376",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.7-dev73",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.6-dev73",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.6-dev72",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.6-beta378",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-dev74",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
+    "download_count": 23
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.7",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
+    "download_count": 141
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.7-beta381",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
+    "download_count": 22
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
+    "download_count": 41
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-dev78",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-dev77",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-dev76",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
+    "download_count": 23
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-beta386",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-beta394",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-dev80",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
+    "download_count": 24
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-beta396",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.9-dev81",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.8-beta399",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.9",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
+    "download_count": 42
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.9-dev82",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.9-beta404",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
+    "download_count": 21
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.10-dev84",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
+    "download_count": 19
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.9-dev84",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
+    "download_count": 19
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.9-beta408",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
+    "download_count": 20
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
+    "download_count": 5
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
+    "download_count": 5
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.10",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
+    "download_count": 35
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.10-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
+    "download_count": 15
+  },
+  {
+    "product": "wpc",
+    "version": "1.3.10-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
+    "download_count": 15
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.10-beta419",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
+    "download_count": 19
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-dev89",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
+    "download_count": 5
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-dev89",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
+    "download_count": 5
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-beta479",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
+    "download_count": 5
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-beta479",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
+    "download_count": 4
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-dev91",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
+    "download_count": 3
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-dev91",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-dev90",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
+    "download_count": 3
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-dev90",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-beta481",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
+    "download_count": 3
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-beta481",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-dev92",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
+    "download_count": 0
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.2-dev92",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
+    "download_count": 0
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-beta486",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
+    "download_count": 3
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.1-beta486",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": "sys11",
+    "version": "1.4.0-beta493",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
+    "download_count": 0
+  },
+  {
+    "product": "wpc",
+    "version": "0.0.2-beta493",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev24",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev22",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "0.3.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
+    "download_count": 50
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev25",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.3.0-beta-116",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-beta123",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-beta126",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "0.4.1-dev28",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-beta130",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.2-dev30",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.1-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.1-beta135",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.3-dev31",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "0.4.3-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.2-beta139",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4-dev32",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.3-beta145",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev35",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.5-dev33",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4-dev34",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.4-beta149",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4-beta160",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.0.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
+    "download_count": 35
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev43",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-beta203",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.1.0-dev45",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev47",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev46",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
+    "download_count": 25
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev44",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-beta211",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-beta225",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev47",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
+    "download_count": 23
+  },
+  {
+    "product": null,
+    "version": "1.1.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.1.0-dev49",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.1.0-dev48",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.1.0-beta227",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.2.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
+    "download_count": 25
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev52",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev51",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev50",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev49",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev48",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta235",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta246",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta247",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta251",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev52",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta254",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev55",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev54",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-beta258",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev58",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev55",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev59",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev57",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev56",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-beta262",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev61",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev60",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev60",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev59",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev56",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-beta310",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev58",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta320",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta319",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev62",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta324",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta327",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev64",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.3",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
+    "download_count": 31
+  },
+  {
+    "product": null,
+    "version": "1.3.3-dev64",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.3-dev63",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.3-beta330",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
+    "download_count": 31
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev67",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev66",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev65",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.4-beta338",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev70",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-beta358",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev67",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-beta361",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.6-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
+    "download_count": 192
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-beta363",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev72",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-beta372",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.6-beta376",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.7-dev73",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.6-dev73",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.6-dev72",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.6-beta378",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev74",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
+    "download_count": 23
+  },
+  {
+    "product": null,
+    "version": "1.3.7",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
+    "download_count": 141
+  },
+  {
+    "product": null,
+    "version": "1.3.7-beta381",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.3.8",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
+    "download_count": 41
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev78",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev77",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev76",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
+    "download_count": 23
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta386",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta394",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev80",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta396",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.9-dev81",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta399",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.9",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
+    "download_count": 42
+  },
+  {
+    "product": null,
+    "version": "1.3.9-dev82",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.9-beta404",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.10-dev84",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
+    "download_count": 19
+  },
+  {
+    "product": null,
+    "version": "1.3.9-dev84",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
+    "download_count": 19
+  },
+  {
+    "product": null,
+    "version": "1.3.9-beta408",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.3.10",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
+    "download_count": 35
+  },
+  {
+    "product": null,
+    "version": "1.3.10-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
+    "download_count": 15
+  },
+  {
+    "product": null,
+    "version": "1.3.10-beta419",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
+    "download_count": 19
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev89",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta479",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev91",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev90",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta481",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev92",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta486",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta493",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.3.0-beta-116",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-beta123",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-beta126",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "0.4.0-beta130",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.1-beta135",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.2-beta139",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.3-beta145",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4-beta149",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4-beta160",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.0.0-beta203",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-beta211",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-beta225",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.1.0-beta227",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta235",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta246",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta247",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta251",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-beta254",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-beta258",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-beta262",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-beta310",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta320",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta319",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta324",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-beta327",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.3-beta330",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-beta338",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-beta358",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-beta361",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-beta363",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-beta372",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.6-beta376",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.6-beta378",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.7-beta381",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta386",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta394",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta396",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-beta399",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.9-beta404",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.9-beta408",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.10-beta419",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
+    "download_count": 19
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta479",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta481",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta486",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-beta493",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev24",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev22",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev25",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.1-dev28",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.0-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.2-dev30",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.1-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.3-dev31",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "0.4.3-dev29",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.4-dev32",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev35",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "0.4.5-dev33",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "0.4.4-dev34",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev43",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.1.0-dev45",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev47",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev46",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
+    "download_count": 25
+  },
+  {
+    "product": null,
+    "version": "1.0.0-dev44",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev47",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
+    "download_count": 23
+  },
+  {
+    "product": null,
+    "version": "1.1.0-dev49",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.1.0-dev48",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev52",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev51",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev50",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev49",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.2.0-dev48",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev52",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev55",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev54",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev58",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev55",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev59",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev57",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.0-dev56",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev61",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev60",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev60",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev59",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.1-dev56",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev58",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev53",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.2-dev62",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev64",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.3-dev64",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.3-dev63",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev67",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev66",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.4-dev65",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev70",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev67",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.6-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev68",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.5-dev72",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.7-dev73",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.6-dev73",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.6-dev72",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev74",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
+    "download_count": 23
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev78",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev77",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev76",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
+    "download_count": 23
+  },
+  {
+    "product": null,
+    "version": "1.3.8-dev80",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
+    "download_count": 24
+  },
+  {
+    "product": null,
+    "version": "1.3.9-dev81",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.9-dev82",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
+    "download_count": 20
+  },
+  {
+    "product": null,
+    "version": "1.3.10-dev84",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
+    "download_count": 19
+  },
+  {
+    "product": null,
+    "version": "1.3.9-dev84",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
+    "download_count": 19
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.3.10-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
+    "download_count": 15
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev89",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev91",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev90",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "1.4.0-dev92",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.3.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
+    "download_count": 50
+  },
+  {
+    "product": null,
+    "version": "0.4.4",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.0.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
+    "download_count": 35
+  },
+  {
+    "product": null,
+    "version": "1.1.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.2.0",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
+    "download_count": 25
+  },
+  {
+    "product": null,
+    "version": "1.3.1",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
+    "download_count": 21
+  },
+  {
+    "product": null,
+    "version": "1.3.2",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
+    "download_count": 22
+  },
+  {
+    "product": null,
+    "version": "1.3.3",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
+    "download_count": 31
+  },
+  {
+    "product": null,
+    "version": "1.3.4",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
+    "download_count": 31
+  },
+  {
+    "product": null,
+    "version": "1.3.5",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
+    "download_count": 192
+  },
+  {
+    "product": null,
+    "version": "1.3.7",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
+    "download_count": 141
+  },
+  {
+    "product": null,
+    "version": "1.3.8",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
+    "download_count": 41
+  },
+  {
+    "product": null,
+    "version": "1.3.9",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
+    "download_count": 42
+  },
+  {
+    "product": null,
+    "version": "1.3.10",
+    "type": "production",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
+    "download_count": 35
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.3.10-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
+    "download_count": 15
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev89",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "0.0.1-beta479",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
+    "download_count": 4
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev91",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev90",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.1-beta481",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.2-dev92",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.0.1-beta486",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.2-beta493",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.0.1-beta479",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
+    "download_count": 4
+  },
+  {
+    "product": null,
+    "version": "0.0.1-beta481",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.1-beta486",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.2-beta493",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
+    "download_count": 0
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "1.3.10-dev83",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
+    "download_count": 15
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev89",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
+    "download_count": 5
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev91",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.1-dev90",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
+    "download_count": 3
+  },
+  {
+    "product": null,
+    "version": "0.0.2-dev92",
+    "type": "dev",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
+    "download_count": 0
+  }
+]

--- a/docs/vector/sys11/all.json
+++ b/docs/vector/sys11/all.json
@@ -4,1063 +4,930 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/24\nBranch: pre-commit-changes\nVersion: 0.4.0-dev24\n",
     "published_at": "2025-01-19T22:45:30+00:00",
-    "type": "dev",
-    "download_count": 24
+    "type": "dev"
   },
   {
     "version": "0.4.0-dev22",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/22\nBranch: Serial_Flash_Test\nVersion: 0.4.0-dev22\n",
     "published_at": "2025-01-19T03:00:13+00:00",
-    "type": "dev",
-    "download_count": 22
+    "type": "dev"
   },
   {
     "version": "0.3.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
     "notes": "1. Added New web interface with dark mode\r\n2. Improved update functionality, no more messing with files\r\n3. Improved Security\r\n4. Minor bug Fixes",
     "published_at": "2025-01-12T02:51:54+00:00",
-    "type": "production",
-    "download_count": 50
+    "type": "production"
   },
   {
     "version": "0.4.0-dev25",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/25\nBranch: network-discovery\nVersion: 0.4.0-dev25\n",
     "published_at": "2025-01-26T19:37:25+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.3.0-beta-116",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.3.0-beta-116\n",
     "published_at": "2025-01-26T17:00:14+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.0-beta123",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.0-beta123\n",
     "published_at": "2025-01-28T22:23:22+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.0-beta126",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.0-beta126\n",
     "published_at": "2025-01-28T23:32:55+00:00",
-    "type": "beta",
-    "download_count": 24
+    "type": "beta"
   },
   {
     "version": "0.4.1-dev28",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/28\nBranch: cancel-button-fix\nVersion: 0.4.1-dev28\n",
     "published_at": "2025-02-01T23:38:40+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.0-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.0-dev29\n",
     "published_at": "2025-02-01T23:42:13+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.0-beta130",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.0-beta130\n",
     "published_at": "2025-02-01T23:36:46+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "0.4.2-dev30",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/30\nBranch: no-discovery-in-ap-mode\nVersion: 0.4.2-dev30\n",
     "published_at": "2025-02-02T02:53:34+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.1-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.1-dev29\n",
     "published_at": "2025-02-01T23:49:39+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.1-beta135",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.1-beta135\n",
     "published_at": "2025-02-01T23:48:13+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.3-dev31",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/31\nBranch: authenticate-for-logs\nVersion: 0.4.3-dev31\n",
     "published_at": "2025-02-02T16:34:19+00:00",
-    "type": "dev",
-    "download_count": 22
+    "type": "dev"
   },
   {
     "version": "0.4.3-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.3-dev29\n",
     "published_at": "2025-02-02T03:21:43+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.2-beta139",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.2-beta139\n",
     "published_at": "2025-02-02T03:06:44+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.4-dev32",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/32\nBranch: main_0_4_0_testing\nVersion: 0.4.4-dev32\n",
     "published_at": "2025-02-03T21:50:24+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.3-beta145",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.3-beta145\n",
     "published_at": "2025-02-02T16:46:59+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.0.0-dev35",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/35\nBranch: update-logic-fix\nVersion: 1.0.0-dev35\n",
     "published_at": "2025-02-06T04:13:37+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.5-dev33",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/33\nBranch: KISS-scores\nVersion: 0.4.5-dev33\n",
     "published_at": "2025-02-05T04:13:36+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.4-dev34",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/34\nBranch: Factory-Reset\nVersion: 0.4.4-dev34\n",
     "published_at": "2025-02-05T19:53:48+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.4-beta149",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.4-beta149\n",
     "published_at": "2025-02-04T01:02:49+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.4",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
     "notes": "## What's Changed\r\n* Added Adjustment Profiles by @mullinmax in https://github.com/warped-pinball/vector/pull/22\r\n  * Save your adjustments as a profile and switch between your profiles easily\r\n* Network discovery by @mullinmax in https://github.com/warped-pinball/vector/pull/25\r\n  * When on the same WiFi network vector boards will identify and add links to each other on their webpages (just click the game name)\r\n* Factory reset by @paulmullin in https://github.com/warped-pinball/vector/pull/34\r\n  * Factory reset now supports clearing all the new features added in this release\r\n\r\n\r\n## Bug Fixes\r\n* Main 0 4 0 testing by @paulmullin in https://github.com/warped-pinball/vector/pull/32\r\n* fixing cancel call back logic by @mullinmax in https://github.com/warped-pinball/vector/pull/28\r\n* Builder tweaks by @mullinmax in https://github.com/warped-pinball/vector/pull/23\r\n* turn off some of schedule when in AP mode by @mullinmax in https://github.com/warped-pinball/vector/pull/30\r\n* correct authentication by @mullinmax in https://github.com/warped-pinball/vector/pull/31\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/0.3.0...0.4.4",
     "published_at": "2025-02-06T23:04:19+00:00",
-    "type": "production",
-    "download_count": 21
+    "type": "production"
   },
   {
     "version": "0.4.4-beta160",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.4-beta160\n",
     "published_at": "2025-02-06T22:57:10+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.0.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
     "notes": "## What's Changed\r\n* New responsive scoreboard\r\n* Added System 9 support\r\n* Added score claim to allow users to enter initials after playing their game, especially for system 9 with no native support for initials\r\n* Improved forward compatibility\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/0.4.4...1.0.0",
     "published_at": "2025-02-23T20:00:09+00:00",
-    "type": "production",
-    "download_count": 35
+    "type": "production"
   },
   {
     "version": "1.0.0-dev43",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/43\nBranch: memory-efficiency\nVersion: 1.0.0-dev43\n",
     "published_at": "2025-02-25T02:49:28+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-beta203",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.0.0-beta203\n",
     "published_at": "2025-02-23T19:57:39+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.1.0-dev45",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/45\nBranch: wifi-reconnect\nVersion: 1.1.0-dev45\n",
     "published_at": "2025-02-26T03:22:37+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.0.0-dev47\n",
     "published_at": "2025-02-26T23:04:19+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev46",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/46\nBranch: logging\nVersion: 1.0.0-dev46\n",
     "published_at": "2025-02-26T03:36:54+00:00",
-    "type": "dev",
-    "download_count": 25
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev44",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/44\nBranch: memory-efficiency\nVersion: 1.0.0-dev44\n",
     "published_at": "2025-02-26T01:38:58+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-beta211",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.0.0-beta211\n",
     "published_at": "2025-02-26T01:31:32+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.0.0-beta225",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.0.0-beta225\n",
     "published_at": "2025-03-01T01:37:48+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.2.0-dev47\n",
     "published_at": "2025-03-01T01:45:10+00:00",
-    "type": "dev",
-    "download_count": 23
+    "type": "dev"
   },
   {
     "version": "1.1.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
     "notes": "## What's Changed\r\n* Added more robust ability to reconnect to WiFi on signal loss @mullinmax in https://github.com/warped-pinball/vector/pull/45\r\n* Restructured code to free up Memory @mullinmax in https://github.com/warped-pinball/vector/pull/43\r\n* Moved some files to firmware to save memory @paulmullin in https://github.com/warped-pinball/vector/pull/46\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.0.0...1.1.0",
     "published_at": "2025-03-01T01:43:01+00:00",
-    "type": "production",
-    "download_count": 22
+    "type": "production"
   },
   {
     "version": "1.1.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.1.0-dev49\n",
     "published_at": "2025-03-02T01:58:59+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.1.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.1.0-dev48\n",
     "published_at": "2025-03-02T01:31:46+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.1.0-beta227",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.1.0-beta227\n",
     "published_at": "2025-03-01T01:39:02+00:00",
-    "type": "beta",
-    "download_count": 22
+    "type": "beta"
   },
   {
     "version": "1.2.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
     "notes": "## What's Changed\r\n* Live game scores by @mullinmax in https://github.com/warped-pinball/vector/pull/47\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.1.0...1.2.0",
     "published_at": "2025-03-02T02:11:58+00:00",
-    "type": "production",
-    "download_count": 25
+    "type": "production"
   },
   {
     "version": "1.2.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.2.0-dev53\n",
     "published_at": "2025-03-02T13:11:53+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.2.0-dev52\n",
     "published_at": "2025-03-02T04:43:50+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev51",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/51\nBranch: show-ip-toggle\nVersion: 1.2.0-dev51\n",
     "published_at": "2025-03-02T02:47:20+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev50",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/50\nBranch: web-ui-claim-toggle\nVersion: 1.2.0-dev50\n",
     "published_at": "2025-03-02T02:15:04+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.2.0-dev49\n",
     "published_at": "2025-03-02T02:20:30+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.2.0-dev48\n",
     "published_at": "2025-03-02T02:20:00+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-beta235",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta235\n",
     "published_at": "2025-03-02T02:11:41+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta246",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta246\n",
     "published_at": "2025-03-02T15:06:22+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta247",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta247\n",
     "published_at": "2025-03-02T15:06:45+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta251",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta251\n",
     "published_at": "2025-03-02T17:51:26+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.3.0-dev52\n",
     "published_at": "2025-03-02T18:26:23+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-beta254",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta254\n",
     "published_at": "2025-03-02T18:14:40+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.0-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.0-dev55\n",
     "published_at": "2025-03-03T00:14:20+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev54",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/54\nBranch: route-quick-fix\nVersion: 1.3.0-dev54\n",
     "published_at": "2025-03-02T23:21:53+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.0-dev53\n",
     "published_at": "2025-03-02T19:21:48+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-beta258",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.0-beta258\n",
     "published_at": "2025-03-02T18:46:18+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.1-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.1-dev58\n",
     "published_at": "2025-03-06T04:10:33+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.1-dev55\n",
     "published_at": "2025-03-06T21:14:36+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.0-dev59\n",
     "published_at": "2025-03-08T01:01:04+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev57",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/57\nBranch: combine-api-routes\nVersion: 1.3.0-dev57\n",
     "published_at": "2025-03-04T03:52:39+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.0-dev56\n",
     "published_at": "2025-03-03T02:31:26+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-beta262",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.0-beta262\n",
     "published_at": "2025-03-03T02:26:06+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-dev61",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/61\nBranch: light-mode-style-fixes\nVersion: 1.3.2-dev61\n",
     "published_at": "2025-03-09T17:10:25+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.2-dev60\n",
     "published_at": "2025-03-09T01:49:28+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
     "notes": "## What's Changed\r\n* More memory efficient web server @mullinmax in https://github.com/warped-pinball/vector/pull/48\r\n* Added toggle to disable claiming scores via the web UI @mullinmax in https://github.com/warped-pinball/vector/pull/50\r\n* Added toggle to disable displaying IP on game @mullinmax in https://github.com/warped-pinball/vector/pull/51\r\n\r\n### Bug fixes\r\n* Various bug fixes and tweaks by @paulmullin in https://github.com/warped-pinball/vector/pull/55\r\n* More robust discovery service by @mullinmax in https://github.com/warped-pinball/vector/pull/49\r\n* linted all JS code and added linter by @mullinmax in https://github.com/warped-pinball/vector/pull/52\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.2.0...1.3.1",
     "published_at": "2025-03-08T01:35:21+00:00",
-    "type": "production",
-    "download_count": 21
+    "type": "production"
   },
   {
     "version": "1.3.1-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.1-dev60\n",
     "published_at": "2025-03-08T04:07:36+00:00",
-    "type": "dev",
-    "download_count": 24
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.1-dev59\n",
     "published_at": "2025-03-09T17:25:13+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.1-dev56\n",
     "published_at": "2025-03-09T17:13:13+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-beta310",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.1-beta310\n",
     "published_at": "2025-03-08T01:30:28+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.2-dev58\n",
     "published_at": "2025-03-09T17:26:50+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.2-dev53\n",
     "published_at": "2025-03-09T17:29:06+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-beta320",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta320\n",
     "published_at": "2025-03-09T17:26:29+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-beta319",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta319\n",
     "published_at": "2025-03-09T17:26:07+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
     "notes": "## What's Changed\r\n* Enabled score claim for tournament mode @paulmullin in https://github.com/warped-pinball/vector/pull/60\r\n## Bug fixes\r\n* Live scores visible on light mode by @mullinmax in https://github.com/warped-pinball/vector/pull/61\r\n* sort tournament scores by chronological order @mullinmax in https://github.com/warped-pinball/vector/pull/59\r\n\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.1...1.3.2",
     "published_at": "2025-03-09T17:35:32+00:00",
-    "type": "production",
-    "download_count": 22
+    "type": "production"
   },
   {
     "version": "1.3.2-dev62",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/62\nBranch: short-initials\nVersion: 1.3.2-dev62\n",
     "published_at": "2025-03-09T20:17:00+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-beta324",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta324\n",
     "published_at": "2025-03-09T17:33:04+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-beta327",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta327\n",
     "published_at": "2025-03-09T21:49:26+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.4-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.4-dev64\n",
     "published_at": "2025-03-12T02:36:22+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.3",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
     "notes": "## What's Changed\r\n\r\n## Bug Fixes\r\n* fix 1 and 2 letter initials by @paulmullin in https://github.com/warped-pinball/vector/pull/62\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.2...1.3.3",
     "published_at": "2025-03-09T21:52:22+00:00",
-    "type": "production",
-    "download_count": 31
+    "type": "production"
   },
   {
     "version": "1.3.3-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.3-dev64\n",
     "published_at": "2025-03-10T22:27:24+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.3-dev63",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/63\nBranch: version-bump\nVersion: 1.3.3-dev63\n",
     "published_at": "2025-03-09T21:51:53+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.3-beta330",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.3-beta330\n",
     "published_at": "2025-03-09T21:51:50+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.4",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
     "notes": "## What's Changed\r\n* Log adjustments and bug fixes by @paulmullin in https://github.com/warped-pinball/vector/pull/64\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.3...1.3.4",
     "published_at": "2025-03-12T02:37:09+00:00",
-    "type": "production",
-    "download_count": 31
+    "type": "production"
   },
   {
     "version": "1.3.4-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.4-dev68\n",
     "published_at": "2025-03-22T14:42:01+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.4-dev67\n",
     "published_at": "2025-03-21T01:50:43+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev66",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/66\nBranch: improved-readme\nVersion: 1.3.4-dev66\n",
     "published_at": "2025-03-20T03:50:27+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev65",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/65\nBranch: Zoom-Demo-TPF\nVersion: 1.3.4-dev65\n",
     "published_at": "2025-03-14T20:48:15+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.4-beta338",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.4-beta338\n",
     "published_at": "2025-03-12T02:36:53+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.5-dev70",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/70\nBranch: version-bump\nVersion: 1.3.5-dev70\n",
     "published_at": "2025-03-23T20:42:40+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-beta358",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.4-beta358\n",
     "published_at": "2025-03-22T20:32:57+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.5-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.5-dev67\n",
     "published_at": "2025-03-23T20:50:37+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5-beta361",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.5-beta361\n",
     "published_at": "2025-03-23T20:44:01+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.6-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.6-dev68\n",
     "published_at": "2025-03-27T19:29:06+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
     "notes": "## What's Changed\r\n* Improved readme by @mullinmax in https://github.com/warped-pinball/vector/pull/66\r\n* Enabled Ball in play for Diner by @paulmullin in https://github.com/warped-pinball/vector/pull/67\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.4...1.3.5",
     "published_at": "2025-03-23T20:52:20+00:00",
-    "type": "production",
-    "download_count": 192
+    "type": "production"
   },
   {
     "version": "1.3.5-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.5-dev68\n",
     "published_at": "2025-03-27T00:43:16+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5-beta363",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.5-beta363\n",
     "published_at": "2025-03-23T20:51:10+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.5-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.5-dev72\n",
     "published_at": "2025-03-28T00:09:24+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5-beta372",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.5-beta372\n",
     "published_at": "2025-03-27T23:54:32+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.6-beta376",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.6-beta376\n",
     "published_at": "2025-03-28T00:12:27+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.7-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.7-dev73\n",
     "published_at": "2025-04-01T00:04:20+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.6-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.6-dev73\n",
     "published_at": "2025-04-01T00:03:22+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.6-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.6-dev72\n",
     "published_at": "2025-03-28T00:12:53+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.6-beta378",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.6-beta378\n",
     "published_at": "2025-03-28T00:13:00+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.8-dev74",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/74\nBranch: sys9-score-fix\nVersion: 1.3.8-dev74\n",
     "published_at": "2025-04-11T17:27:47+00:00",
-    "type": "dev",
-    "download_count": 23
+    "type": "dev"
   },
   {
     "version": "1.3.7",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
     "notes": "## What's Changed\r\n* Added manual port by @JakeSiegers in https://github.com/warped-pinball/vector/pull/71\r\n\r\n## Bug fixes\r\n* Clear Existing scores from live scores between games by @mullinmax in https://github.com/warped-pinball/vector/pull/68\r\n* space station config fix by @paulmullin in https://github.com/warped-pinball/vector/pull/73\r\n\r\n## Documentation\r\n* Add contributors to Readme by @mullinmax in https://github.com/warped-pinball/vector/pull/72\r\n\r\n## New Contributors\r\n* @JakeSiegers made their first contribution in https://github.com/warped-pinball/vector/pull/71\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.5...1.3.7",
     "published_at": "2025-04-01T01:06:38+00:00",
-    "type": "production",
-    "download_count": 141
+    "type": "production"
   },
   {
     "version": "1.3.7-beta381",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.7-beta381\n",
     "published_at": "2025-04-01T00:42:48+00:00",
-    "type": "beta",
-    "download_count": 22
+    "type": "beta"
   },
   {
     "version": "1.3.8",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
     "notes": "## What's Changed\r\n* Sys9 score fix by @paulmullin in https://github.com/warped-pinball/vector/pull/74\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.7...1.3.8",
     "published_at": "2025-04-11T18:53:28+00:00",
-    "type": "production",
-    "download_count": 41
+    "type": "production"
   },
   {
     "version": "1.3.8-dev78",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/78\nBranch: wifi-retry-timeout\nVersion: 1.3.8-dev78\n",
     "published_at": "2025-05-03T01:41:00+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev77",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/77\nBranch: improved-discover\nVersion: 1.3.8-dev77\n",
     "published_at": "2025-04-17T21:38:55+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev76",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/76\nBranch: Sorcerer-add\nVersion: 1.3.8-dev76\n",
     "published_at": "2025-04-16T23:34:10+00:00",
-    "type": "dev",
-    "download_count": 23
+    "type": "dev"
   },
   {
     "version": "1.3.8-beta386",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta386\n",
     "published_at": "2025-04-11T18:47:45+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.8-beta394",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta394\n",
     "published_at": "2025-05-06T00:11:44+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.8-dev80",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/80\nBranch: Whirlwind-Live-Scores\nVersion: 1.3.8-dev80\n",
     "published_at": "2025-05-20T01:46:42+00:00",
-    "type": "dev",
-    "download_count": 24
+    "type": "dev"
   },
   {
     "version": "1.3.8-beta396",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta396\n",
     "published_at": "2025-05-20T00:53:56+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.9-dev81",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/81\nBranch: version-bump\nVersion: 1.3.9-dev81\n",
     "published_at": "2025-05-21T02:01:22+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.8-beta399",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta399\n",
     "published_at": "2025-05-20T02:38:42+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.9",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
     "notes": "## What's Changed\r\n* Improved handling booting with no WiFi signal by @mullinmax in https://github.com/warped-pinball/vector/pull/78\r\n* Added config for Sorcerer_L2 by @paulmullin in https://github.com/warped-pinball/vector/pull/76\r\n* Corrected Live scores for Whirlwind by @paulmullin in https://github.com/warped-pinball/vector/pull/80\r\n* Fixed ReadMe Shield links by @mullinmax in https://github.com/warped-pinball/vector/pull/81\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.8...1.3.9",
     "published_at": "2025-05-21T02:08:23+00:00",
-    "type": "production",
-    "download_count": 42
+    "type": "production"
   },
   {
     "version": "1.3.9-dev82",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/82\nBranch: leader_reset\nVersion: 1.3.9-dev82\n",
     "published_at": "2025-05-26T21:08:30+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.9-beta404",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.9-beta404\n",
     "published_at": "2025-05-21T02:04:22+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.10-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.10-dev84\n",
     "published_at": "2025-06-18T23:57:48+00:00",
-    "type": "dev",
-    "download_count": 19
+    "type": "dev"
   },
   {
     "version": "1.3.9-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.9-dev84\n",
     "published_at": "2025-06-18T23:56:13+00:00",
-    "type": "dev",
-    "download_count": 19
+    "type": "dev"
   },
   {
     "version": "1.3.9-beta408",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.9-beta408\n",
     "published_at": "2025-05-26T22:24:34+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.4.0-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev83`\n**Sys11**: `1.4.0-dev83`\n**WPC**: `0.0.1-dev83`\n**EM**: `0.0.1-dev83`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-06-24T01:11:06+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "1.3.10",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
     "notes": "## What's Changed\r\n* move leader reset function by @paulmullin in https://github.com/warped-pinball/vector/pull/82\r\n* Fire inplay score address by @paulmullin in https://github.com/warped-pinball/vector/pull/84\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.9...1.3.10",
     "published_at": "2025-06-19T00:22:28+00:00",
-    "type": "production",
-    "download_count": 35
+    "type": "production"
   },
   {
     "version": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
     "notes": "Version: 1.3.10-dev83\nTrigger: pull_request\n",
     "published_at": "2025-06-19T02:25:50+00:00",
-    "type": "dev",
-    "download_count": 15
+    "type": "dev"
   },
   {
     "version": "1.3.10-beta419",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.10-beta419\n",
     "published_at": "2025-06-19T00:22:15+00:00",
-    "type": "beta",
-    "download_count": 19
+    "type": "beta"
   },
   {
     "version": "1.4.0-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev89`\n**Sys11**: `1.4.0-dev89`\n**WPC**: `0.0.1-dev89`\n**EM**: `0.0.1-dev89`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:30:41+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "1.4.0-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta479`\n**Sys11**: `1.4.0-beta479`\n**WPC**: `0.0.1-beta479`\n**EM**: `0.0.1-beta479`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:07:23+00:00",
-    "type": "beta",
-    "download_count": 5
+    "type": "beta"
   },
   {
     "version": "1.4.0-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev91`\n**Sys11**: `1.4.0-dev91`\n**WPC**: `0.0.1-dev91`\n**EM**: `0.0.1-dev91`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T19:03:49+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "1.4.0-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev90`\n**Sys11**: `1.4.0-dev90`\n**WPC**: `0.0.1-dev90`\n**EM**: `0.0.1-dev90`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T18:50:19+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "1.4.0-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta481`\n**Sys11**: `1.4.0-beta481`\n**WPC**: `0.0.1-beta481`\n**EM**: `0.0.1-beta481`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T16:17:59+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "1.4.0-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev92`\n**Sys11**: `1.4.0-dev92`\n**WPC**: `0.0.2-dev92`\n**EM**: `0.0.1-dev92`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-12T22:23:49+00:00",
-    "type": "dev",
-    "download_count": 0
+    "type": "dev"
   },
   {
     "version": "1.4.0-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta486`\n**Sys11**: `1.4.0-beta486`\n**WPC**: `0.0.1-beta486`\n**EM**: `0.0.1-beta486`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T22:43:34+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "1.4.0-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta493`\n**Sys11**: `1.4.0-beta493`\n**WPC**: `0.0.2-beta493`\n**EM**: `0.0.1-beta493`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-18T20:12:57+00:00",
-    "type": "beta",
-    "download_count": 0
+    "type": "beta"
   }
 ]

--- a/docs/vector/sys11/beta.json
+++ b/docs/vector/sys11/beta.json
@@ -4,359 +4,314 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.3.0-beta-116\n",
     "published_at": "2025-01-26T17:00:14+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.0-beta123",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.0-beta123\n",
     "published_at": "2025-01-28T22:23:22+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.0-beta126",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.0-beta126\n",
     "published_at": "2025-01-28T23:32:55+00:00",
-    "type": "beta",
-    "download_count": 24
+    "type": "beta"
   },
   {
     "version": "0.4.0-beta130",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.0-beta130\n",
     "published_at": "2025-02-01T23:36:46+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "0.4.1-beta135",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.1-beta135\n",
     "published_at": "2025-02-01T23:48:13+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.2-beta139",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.2-beta139\n",
     "published_at": "2025-02-02T03:06:44+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.3-beta145",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.3-beta145\n",
     "published_at": "2025-02-02T16:46:59+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.4-beta149",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.4-beta149\n",
     "published_at": "2025-02-04T01:02:49+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "0.4.4-beta160",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
     "notes": "PR: \nBranch: \nVersion: 0.4.4-beta160\n",
     "published_at": "2025-02-06T22:57:10+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.0.0-beta203",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.0.0-beta203\n",
     "published_at": "2025-02-23T19:57:39+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.0.0-beta211",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.0.0-beta211\n",
     "published_at": "2025-02-26T01:31:32+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.0.0-beta225",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.0.0-beta225\n",
     "published_at": "2025-03-01T01:37:48+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.1.0-beta227",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.1.0-beta227\n",
     "published_at": "2025-03-01T01:39:02+00:00",
-    "type": "beta",
-    "download_count": 22
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta235",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta235\n",
     "published_at": "2025-03-02T02:11:41+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta246",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta246\n",
     "published_at": "2025-03-02T15:06:22+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta247",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta247\n",
     "published_at": "2025-03-02T15:06:45+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta251",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta251\n",
     "published_at": "2025-03-02T17:51:26+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.2.0-beta254",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.2.0-beta254\n",
     "published_at": "2025-03-02T18:14:40+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.0-beta258",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.0-beta258\n",
     "published_at": "2025-03-02T18:46:18+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.0-beta262",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.0-beta262\n",
     "published_at": "2025-03-03T02:26:06+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.1-beta310",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.1-beta310\n",
     "published_at": "2025-03-08T01:30:28+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-beta320",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta320\n",
     "published_at": "2025-03-09T17:26:29+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-beta319",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta319\n",
     "published_at": "2025-03-09T17:26:07+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-beta324",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta324\n",
     "published_at": "2025-03-09T17:33:04+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.2-beta327",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.2-beta327\n",
     "published_at": "2025-03-09T21:49:26+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.3-beta330",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.3-beta330\n",
     "published_at": "2025-03-09T21:51:50+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.4-beta338",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.4-beta338\n",
     "published_at": "2025-03-12T02:36:53+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.4-beta358",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.4-beta358\n",
     "published_at": "2025-03-22T20:32:57+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.5-beta361",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.5-beta361\n",
     "published_at": "2025-03-23T20:44:01+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.5-beta363",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.5-beta363\n",
     "published_at": "2025-03-23T20:51:10+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.5-beta372",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.5-beta372\n",
     "published_at": "2025-03-27T23:54:32+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.6-beta376",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.6-beta376\n",
     "published_at": "2025-03-28T00:12:27+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.6-beta378",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.6-beta378\n",
     "published_at": "2025-03-28T00:13:00+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.7-beta381",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.7-beta381\n",
     "published_at": "2025-04-01T00:42:48+00:00",
-    "type": "beta",
-    "download_count": 22
+    "type": "beta"
   },
   {
     "version": "1.3.8-beta386",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta386\n",
     "published_at": "2025-04-11T18:47:45+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.8-beta394",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta394\n",
     "published_at": "2025-05-06T00:11:44+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.8-beta396",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta396\n",
     "published_at": "2025-05-20T00:53:56+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.8-beta399",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.8-beta399\n",
     "published_at": "2025-05-20T02:38:42+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.9-beta404",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.9-beta404\n",
     "published_at": "2025-05-21T02:04:22+00:00",
-    "type": "beta",
-    "download_count": 21
+    "type": "beta"
   },
   {
     "version": "1.3.9-beta408",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.9-beta408\n",
     "published_at": "2025-05-26T22:24:34+00:00",
-    "type": "beta",
-    "download_count": 20
+    "type": "beta"
   },
   {
     "version": "1.3.10-beta419",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
     "notes": "PR: \nBranch: \nVersion: 1.3.10-beta419\n",
     "published_at": "2025-06-19T00:22:15+00:00",
-    "type": "beta",
-    "download_count": 19
+    "type": "beta"
   },
   {
     "version": "1.4.0-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta479`\n**Sys11**: `1.4.0-beta479`\n**WPC**: `0.0.1-beta479`\n**EM**: `0.0.1-beta479`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:07:23+00:00",
-    "type": "beta",
-    "download_count": 5
+    "type": "beta"
   },
   {
     "version": "1.4.0-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta481`\n**Sys11**: `1.4.0-beta481`\n**WPC**: `0.0.1-beta481`\n**EM**: `0.0.1-beta481`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T16:17:59+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "1.4.0-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta486`\n**Sys11**: `1.4.0-beta486`\n**WPC**: `0.0.1-beta486`\n**EM**: `0.0.1-beta486`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T22:43:34+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "1.4.0-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta493`\n**Sys11**: `1.4.0-beta493`\n**WPC**: `0.0.2-beta493`\n**EM**: `0.0.1-beta493`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-18T20:12:57+00:00",
-    "type": "beta",
-    "download_count": 0
+    "type": "beta"
   }
 ]

--- a/docs/vector/sys11/dev.json
+++ b/docs/vector/sys11/dev.json
@@ -4,591 +4,517 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/24\nBranch: pre-commit-changes\nVersion: 0.4.0-dev24\n",
     "published_at": "2025-01-19T22:45:30+00:00",
-    "type": "dev",
-    "download_count": 24
+    "type": "dev"
   },
   {
     "version": "0.4.0-dev22",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/22\nBranch: Serial_Flash_Test\nVersion: 0.4.0-dev22\n",
     "published_at": "2025-01-19T03:00:13+00:00",
-    "type": "dev",
-    "download_count": 22
+    "type": "dev"
   },
   {
     "version": "0.4.0-dev25",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/25\nBranch: network-discovery\nVersion: 0.4.0-dev25\n",
     "published_at": "2025-01-26T19:37:25+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.1-dev28",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/28\nBranch: cancel-button-fix\nVersion: 0.4.1-dev28\n",
     "published_at": "2025-02-01T23:38:40+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.0-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.0-dev29\n",
     "published_at": "2025-02-01T23:42:13+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.2-dev30",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/30\nBranch: no-discovery-in-ap-mode\nVersion: 0.4.2-dev30\n",
     "published_at": "2025-02-02T02:53:34+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.1-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.1-dev29\n",
     "published_at": "2025-02-01T23:49:39+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.3-dev31",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/31\nBranch: authenticate-for-logs\nVersion: 0.4.3-dev31\n",
     "published_at": "2025-02-02T16:34:19+00:00",
-    "type": "dev",
-    "download_count": 22
+    "type": "dev"
   },
   {
     "version": "0.4.3-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.3-dev29\n",
     "published_at": "2025-02-02T03:21:43+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.4-dev32",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/32\nBranch: main_0_4_0_testing\nVersion: 0.4.4-dev32\n",
     "published_at": "2025-02-03T21:50:24+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev35",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/35\nBranch: update-logic-fix\nVersion: 1.0.0-dev35\n",
     "published_at": "2025-02-06T04:13:37+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "0.4.5-dev33",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/33\nBranch: KISS-scores\nVersion: 0.4.5-dev33\n",
     "published_at": "2025-02-05T04:13:36+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "0.4.4-dev34",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/34\nBranch: Factory-Reset\nVersion: 0.4.4-dev34\n",
     "published_at": "2025-02-05T19:53:48+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev43",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/43\nBranch: memory-efficiency\nVersion: 1.0.0-dev43\n",
     "published_at": "2025-02-25T02:49:28+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.1.0-dev45",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/45\nBranch: wifi-reconnect\nVersion: 1.1.0-dev45\n",
     "published_at": "2025-02-26T03:22:37+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.0.0-dev47\n",
     "published_at": "2025-02-26T23:04:19+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev46",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/46\nBranch: logging\nVersion: 1.0.0-dev46\n",
     "published_at": "2025-02-26T03:36:54+00:00",
-    "type": "dev",
-    "download_count": 25
+    "type": "dev"
   },
   {
     "version": "1.0.0-dev44",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/44\nBranch: memory-efficiency\nVersion: 1.0.0-dev44\n",
     "published_at": "2025-02-26T01:38:58+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.2.0-dev47\n",
     "published_at": "2025-03-01T01:45:10+00:00",
-    "type": "dev",
-    "download_count": 23
+    "type": "dev"
   },
   {
     "version": "1.1.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.1.0-dev49\n",
     "published_at": "2025-03-02T01:58:59+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.1.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.1.0-dev48\n",
     "published_at": "2025-03-02T01:31:46+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.2.0-dev53\n",
     "published_at": "2025-03-02T13:11:53+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.2.0-dev52\n",
     "published_at": "2025-03-02T04:43:50+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev51",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/51\nBranch: show-ip-toggle\nVersion: 1.2.0-dev51\n",
     "published_at": "2025-03-02T02:47:20+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev50",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/50\nBranch: web-ui-claim-toggle\nVersion: 1.2.0-dev50\n",
     "published_at": "2025-03-02T02:15:04+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.2.0-dev49\n",
     "published_at": "2025-03-02T02:20:30+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.2.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.2.0-dev48\n",
     "published_at": "2025-03-02T02:20:00+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.3.0-dev52\n",
     "published_at": "2025-03-02T18:26:23+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.0-dev55\n",
     "published_at": "2025-03-03T00:14:20+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev54",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/54\nBranch: route-quick-fix\nVersion: 1.3.0-dev54\n",
     "published_at": "2025-03-02T23:21:53+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.0-dev53\n",
     "published_at": "2025-03-02T19:21:48+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.1-dev58\n",
     "published_at": "2025-03-06T04:10:33+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.1-dev55\n",
     "published_at": "2025-03-06T21:14:36+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.0-dev59\n",
     "published_at": "2025-03-08T01:01:04+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev57",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/57\nBranch: combine-api-routes\nVersion: 1.3.0-dev57\n",
     "published_at": "2025-03-04T03:52:39+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.0-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.0-dev56\n",
     "published_at": "2025-03-03T02:31:26+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev61",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/61\nBranch: light-mode-style-fixes\nVersion: 1.3.2-dev61\n",
     "published_at": "2025-03-09T17:10:25+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.2-dev60\n",
     "published_at": "2025-03-09T01:49:28+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.1-dev60\n",
     "published_at": "2025-03-08T04:07:36+00:00",
-    "type": "dev",
-    "download_count": 24
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.1-dev59\n",
     "published_at": "2025-03-09T17:25:13+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.1-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.1-dev56\n",
     "published_at": "2025-03-09T17:13:13+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.2-dev58\n",
     "published_at": "2025-03-09T17:26:50+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.2-dev53\n",
     "published_at": "2025-03-09T17:29:06+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.2-dev62",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/62\nBranch: short-initials\nVersion: 1.3.2-dev62\n",
     "published_at": "2025-03-09T20:17:00+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.4-dev64\n",
     "published_at": "2025-03-12T02:36:22+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.3-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.3-dev64\n",
     "published_at": "2025-03-10T22:27:24+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.3-dev63",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/63\nBranch: version-bump\nVersion: 1.3.3-dev63\n",
     "published_at": "2025-03-09T21:51:53+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.4-dev68\n",
     "published_at": "2025-03-22T14:42:01+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.4-dev67\n",
     "published_at": "2025-03-21T01:50:43+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev66",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/66\nBranch: improved-readme\nVersion: 1.3.4-dev66\n",
     "published_at": "2025-03-20T03:50:27+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.4-dev65",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/65\nBranch: Zoom-Demo-TPF\nVersion: 1.3.4-dev65\n",
     "published_at": "2025-03-14T20:48:15+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.5-dev70",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/70\nBranch: version-bump\nVersion: 1.3.5-dev70\n",
     "published_at": "2025-03-23T20:42:40+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.5-dev67\n",
     "published_at": "2025-03-23T20:50:37+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.6-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.6-dev68\n",
     "published_at": "2025-03-27T19:29:06+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.5-dev68\n",
     "published_at": "2025-03-27T00:43:16+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.5-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.5-dev72\n",
     "published_at": "2025-03-28T00:09:24+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.7-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.7-dev73\n",
     "published_at": "2025-04-01T00:04:20+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.6-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.6-dev73\n",
     "published_at": "2025-04-01T00:03:22+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.6-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.6-dev72\n",
     "published_at": "2025-03-28T00:12:53+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev74",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/74\nBranch: sys9-score-fix\nVersion: 1.3.8-dev74\n",
     "published_at": "2025-04-11T17:27:47+00:00",
-    "type": "dev",
-    "download_count": 23
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev78",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/78\nBranch: wifi-retry-timeout\nVersion: 1.3.8-dev78\n",
     "published_at": "2025-05-03T01:41:00+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev77",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/77\nBranch: improved-discover\nVersion: 1.3.8-dev77\n",
     "published_at": "2025-04-17T21:38:55+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev76",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/76\nBranch: Sorcerer-add\nVersion: 1.3.8-dev76\n",
     "published_at": "2025-04-16T23:34:10+00:00",
-    "type": "dev",
-    "download_count": 23
+    "type": "dev"
   },
   {
     "version": "1.3.8-dev80",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/80\nBranch: Whirlwind-Live-Scores\nVersion: 1.3.8-dev80\n",
     "published_at": "2025-05-20T01:46:42+00:00",
-    "type": "dev",
-    "download_count": 24
+    "type": "dev"
   },
   {
     "version": "1.3.9-dev81",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/81\nBranch: version-bump\nVersion: 1.3.9-dev81\n",
     "published_at": "2025-05-21T02:01:22+00:00",
-    "type": "dev",
-    "download_count": 21
+    "type": "dev"
   },
   {
     "version": "1.3.9-dev82",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/82\nBranch: leader_reset\nVersion: 1.3.9-dev82\n",
     "published_at": "2025-05-26T21:08:30+00:00",
-    "type": "dev",
-    "download_count": 20
+    "type": "dev"
   },
   {
     "version": "1.3.10-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.10-dev84\n",
     "published_at": "2025-06-18T23:57:48+00:00",
-    "type": "dev",
-    "download_count": 19
+    "type": "dev"
   },
   {
     "version": "1.3.9-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
     "notes": "PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.9-dev84\n",
     "published_at": "2025-06-18T23:56:13+00:00",
-    "type": "dev",
-    "download_count": 19
+    "type": "dev"
   },
   {
     "version": "1.4.0-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev83`\n**Sys11**: `1.4.0-dev83`\n**WPC**: `0.0.1-dev83`\n**EM**: `0.0.1-dev83`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-06-24T01:11:06+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
     "notes": "Version: 1.3.10-dev83\nTrigger: pull_request\n",
     "published_at": "2025-06-19T02:25:50+00:00",
-    "type": "dev",
-    "download_count": 15
+    "type": "dev"
   },
   {
     "version": "1.4.0-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev89`\n**Sys11**: `1.4.0-dev89`\n**WPC**: `0.0.1-dev89`\n**EM**: `0.0.1-dev89`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:30:41+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "1.4.0-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev91`\n**Sys11**: `1.4.0-dev91`\n**WPC**: `0.0.1-dev91`\n**EM**: `0.0.1-dev91`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T19:03:49+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "1.4.0-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev90`\n**Sys11**: `1.4.0-dev90`\n**WPC**: `0.0.1-dev90`\n**EM**: `0.0.1-dev90`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T18:50:19+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "1.4.0-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev92`\n**Sys11**: `1.4.0-dev92`\n**WPC**: `0.0.2-dev92`\n**EM**: `0.0.1-dev92`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-12T22:23:49+00:00",
-    "type": "dev",
-    "download_count": 0
+    "type": "dev"
   }
 ]

--- a/docs/vector/sys11/prod.json
+++ b/docs/vector/sys11/prod.json
@@ -4,111 +4,97 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
     "notes": "1. Added New web interface with dark mode\r\n2. Improved update functionality, no more messing with files\r\n3. Improved Security\r\n4. Minor bug Fixes",
     "published_at": "2025-01-12T02:51:54+00:00",
-    "type": "production",
-    "download_count": 50
+    "type": "production"
   },
   {
     "version": "0.4.4",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
     "notes": "## What's Changed\r\n* Added Adjustment Profiles by @mullinmax in https://github.com/warped-pinball/vector/pull/22\r\n  * Save your adjustments as a profile and switch between your profiles easily\r\n* Network discovery by @mullinmax in https://github.com/warped-pinball/vector/pull/25\r\n  * When on the same WiFi network vector boards will identify and add links to each other on their webpages (just click the game name)\r\n* Factory reset by @paulmullin in https://github.com/warped-pinball/vector/pull/34\r\n  * Factory reset now supports clearing all the new features added in this release\r\n\r\n\r\n## Bug Fixes\r\n* Main 0 4 0 testing by @paulmullin in https://github.com/warped-pinball/vector/pull/32\r\n* fixing cancel call back logic by @mullinmax in https://github.com/warped-pinball/vector/pull/28\r\n* Builder tweaks by @mullinmax in https://github.com/warped-pinball/vector/pull/23\r\n* turn off some of schedule when in AP mode by @mullinmax in https://github.com/warped-pinball/vector/pull/30\r\n* correct authentication by @mullinmax in https://github.com/warped-pinball/vector/pull/31\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/0.3.0...0.4.4",
     "published_at": "2025-02-06T23:04:19+00:00",
-    "type": "production",
-    "download_count": 21
+    "type": "production"
   },
   {
     "version": "1.0.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
     "notes": "## What's Changed\r\n* New responsive scoreboard\r\n* Added System 9 support\r\n* Added score claim to allow users to enter initials after playing their game, especially for system 9 with no native support for initials\r\n* Improved forward compatibility\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/0.4.4...1.0.0",
     "published_at": "2025-02-23T20:00:09+00:00",
-    "type": "production",
-    "download_count": 35
+    "type": "production"
   },
   {
     "version": "1.1.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
     "notes": "## What's Changed\r\n* Added more robust ability to reconnect to WiFi on signal loss @mullinmax in https://github.com/warped-pinball/vector/pull/45\r\n* Restructured code to free up Memory @mullinmax in https://github.com/warped-pinball/vector/pull/43\r\n* Moved some files to firmware to save memory @paulmullin in https://github.com/warped-pinball/vector/pull/46\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.0.0...1.1.0",
     "published_at": "2025-03-01T01:43:01+00:00",
-    "type": "production",
-    "download_count": 22
+    "type": "production"
   },
   {
     "version": "1.2.0",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
     "notes": "## What's Changed\r\n* Live game scores by @mullinmax in https://github.com/warped-pinball/vector/pull/47\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.1.0...1.2.0",
     "published_at": "2025-03-02T02:11:58+00:00",
-    "type": "production",
-    "download_count": 25
+    "type": "production"
   },
   {
     "version": "1.3.1",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
     "notes": "## What's Changed\r\n* More memory efficient web server @mullinmax in https://github.com/warped-pinball/vector/pull/48\r\n* Added toggle to disable claiming scores via the web UI @mullinmax in https://github.com/warped-pinball/vector/pull/50\r\n* Added toggle to disable displaying IP on game @mullinmax in https://github.com/warped-pinball/vector/pull/51\r\n\r\n### Bug fixes\r\n* Various bug fixes and tweaks by @paulmullin in https://github.com/warped-pinball/vector/pull/55\r\n* More robust discovery service by @mullinmax in https://github.com/warped-pinball/vector/pull/49\r\n* linted all JS code and added linter by @mullinmax in https://github.com/warped-pinball/vector/pull/52\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.2.0...1.3.1",
     "published_at": "2025-03-08T01:35:21+00:00",
-    "type": "production",
-    "download_count": 21
+    "type": "production"
   },
   {
     "version": "1.3.2",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
     "notes": "## What's Changed\r\n* Enabled score claim for tournament mode @paulmullin in https://github.com/warped-pinball/vector/pull/60\r\n## Bug fixes\r\n* Live scores visible on light mode by @mullinmax in https://github.com/warped-pinball/vector/pull/61\r\n* sort tournament scores by chronological order @mullinmax in https://github.com/warped-pinball/vector/pull/59\r\n\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.1...1.3.2",
     "published_at": "2025-03-09T17:35:32+00:00",
-    "type": "production",
-    "download_count": 22
+    "type": "production"
   },
   {
     "version": "1.3.3",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
     "notes": "## What's Changed\r\n\r\n## Bug Fixes\r\n* fix 1 and 2 letter initials by @paulmullin in https://github.com/warped-pinball/vector/pull/62\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.2...1.3.3",
     "published_at": "2025-03-09T21:52:22+00:00",
-    "type": "production",
-    "download_count": 31
+    "type": "production"
   },
   {
     "version": "1.3.4",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
     "notes": "## What's Changed\r\n* Log adjustments and bug fixes by @paulmullin in https://github.com/warped-pinball/vector/pull/64\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.3...1.3.4",
     "published_at": "2025-03-12T02:37:09+00:00",
-    "type": "production",
-    "download_count": 31
+    "type": "production"
   },
   {
     "version": "1.3.5",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
     "notes": "## What's Changed\r\n* Improved readme by @mullinmax in https://github.com/warped-pinball/vector/pull/66\r\n* Enabled Ball in play for Diner by @paulmullin in https://github.com/warped-pinball/vector/pull/67\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.4...1.3.5",
     "published_at": "2025-03-23T20:52:20+00:00",
-    "type": "production",
-    "download_count": 192
+    "type": "production"
   },
   {
     "version": "1.3.7",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
     "notes": "## What's Changed\r\n* Added manual port by @JakeSiegers in https://github.com/warped-pinball/vector/pull/71\r\n\r\n## Bug fixes\r\n* Clear Existing scores from live scores between games by @mullinmax in https://github.com/warped-pinball/vector/pull/68\r\n* space station config fix by @paulmullin in https://github.com/warped-pinball/vector/pull/73\r\n\r\n## Documentation\r\n* Add contributors to Readme by @mullinmax in https://github.com/warped-pinball/vector/pull/72\r\n\r\n## New Contributors\r\n* @JakeSiegers made their first contribution in https://github.com/warped-pinball/vector/pull/71\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.5...1.3.7",
     "published_at": "2025-04-01T01:06:38+00:00",
-    "type": "production",
-    "download_count": 141
+    "type": "production"
   },
   {
     "version": "1.3.8",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
     "notes": "## What's Changed\r\n* Sys9 score fix by @paulmullin in https://github.com/warped-pinball/vector/pull/74\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.7...1.3.8",
     "published_at": "2025-04-11T18:53:28+00:00",
-    "type": "production",
-    "download_count": 41
+    "type": "production"
   },
   {
     "version": "1.3.9",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
     "notes": "## What's Changed\r\n* Improved handling booting with no WiFi signal by @mullinmax in https://github.com/warped-pinball/vector/pull/78\r\n* Added config for Sorcerer_L2 by @paulmullin in https://github.com/warped-pinball/vector/pull/76\r\n* Corrected Live scores for Whirlwind by @paulmullin in https://github.com/warped-pinball/vector/pull/80\r\n* Fixed ReadMe Shield links by @mullinmax in https://github.com/warped-pinball/vector/pull/81\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.8...1.3.9",
     "published_at": "2025-05-21T02:08:23+00:00",
-    "type": "production",
-    "download_count": 42
+    "type": "production"
   },
   {
     "version": "1.3.10",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
     "notes": "## What's Changed\r\n* move leader reset function by @paulmullin in https://github.com/warped-pinball/vector/pull/82\r\n* Fire inplay score address by @paulmullin in https://github.com/warped-pinball/vector/pull/84\r\n\r\n\r\n**Full Changelog**: https://github.com/warped-pinball/vector/compare/1.3.9...1.3.10",
     "published_at": "2025-06-19T00:22:28+00:00",
-    "type": "production",
-    "download_count": 35
+    "type": "production"
   }
 ]

--- a/docs/vector/wpc/all.json
+++ b/docs/vector/wpc/all.json
@@ -4,79 +4,69 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev83`\n**Sys11**: `1.4.0-dev83`\n**WPC**: `0.0.1-dev83`\n**EM**: `0.0.1-dev83`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-06-24T01:11:06+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
     "notes": "Version: 1.3.10-dev83\nTrigger: pull_request\n",
     "published_at": "2025-06-19T02:25:50+00:00",
-    "type": "dev",
-    "download_count": 15
+    "type": "dev"
   },
   {
     "version": "0.0.1-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev89`\n**Sys11**: `1.4.0-dev89`\n**WPC**: `0.0.1-dev89`\n**EM**: `0.0.1-dev89`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:30:41+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "0.0.1-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta479`\n**Sys11**: `1.4.0-beta479`\n**WPC**: `0.0.1-beta479`\n**EM**: `0.0.1-beta479`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:07:23+00:00",
-    "type": "beta",
-    "download_count": 4
+    "type": "beta"
   },
   {
     "version": "0.0.1-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev91`\n**Sys11**: `1.4.0-dev91`\n**WPC**: `0.0.1-dev91`\n**EM**: `0.0.1-dev91`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T19:03:49+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "0.0.1-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev90`\n**Sys11**: `1.4.0-dev90`\n**WPC**: `0.0.1-dev90`\n**EM**: `0.0.1-dev90`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T18:50:19+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "0.0.1-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta481`\n**Sys11**: `1.4.0-beta481`\n**WPC**: `0.0.1-beta481`\n**EM**: `0.0.1-beta481`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T16:17:59+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "0.0.2-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev92`\n**Sys11**: `1.4.0-dev92`\n**WPC**: `0.0.2-dev92`\n**EM**: `0.0.1-dev92`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-12T22:23:49+00:00",
-    "type": "dev",
-    "download_count": 0
+    "type": "dev"
   },
   {
     "version": "0.0.1-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta486`\n**Sys11**: `1.4.0-beta486`\n**WPC**: `0.0.1-beta486`\n**EM**: `0.0.1-beta486`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T22:43:34+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "0.0.2-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta493`\n**Sys11**: `1.4.0-beta493`\n**WPC**: `0.0.2-beta493`\n**EM**: `0.0.1-beta493`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-18T20:12:57+00:00",
-    "type": "beta",
-    "download_count": 0
+    "type": "beta"
   }
 ]

--- a/docs/vector/wpc/beta.json
+++ b/docs/vector/wpc/beta.json
@@ -4,31 +4,27 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta479`\n**Sys11**: `1.4.0-beta479`\n**WPC**: `0.0.1-beta479`\n**EM**: `0.0.1-beta479`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:07:23+00:00",
-    "type": "beta",
-    "download_count": 4
+    "type": "beta"
   },
   {
     "version": "0.0.1-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta481`\n**Sys11**: `1.4.0-beta481`\n**WPC**: `0.0.1-beta481`\n**EM**: `0.0.1-beta481`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T16:17:59+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "0.0.1-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta486`\n**Sys11**: `1.4.0-beta486`\n**WPC**: `0.0.1-beta486`\n**EM**: `0.0.1-beta486`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T22:43:34+00:00",
-    "type": "beta",
-    "download_count": 3
+    "type": "beta"
   },
   {
     "version": "0.0.2-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-beta493`\n**Sys11**: `1.4.0-beta493`\n**WPC**: `0.0.2-beta493`\n**EM**: `0.0.1-beta493`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-18T20:12:57+00:00",
-    "type": "beta",
-    "download_count": 0
+    "type": "beta"
   }
 ]

--- a/docs/vector/wpc/dev.json
+++ b/docs/vector/wpc/dev.json
@@ -4,47 +4,41 @@
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev83`\n**Sys11**: `1.4.0-dev83`\n**WPC**: `0.0.1-dev83`\n**EM**: `0.0.1-dev83`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-06-24T01:11:06+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
     "notes": "Version: 1.3.10-dev83\nTrigger: pull_request\n",
     "published_at": "2025-06-19T02:25:50+00:00",
-    "type": "dev",
-    "download_count": 15
+    "type": "dev"
   },
   {
     "version": "0.0.1-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev89`\n**Sys11**: `1.4.0-dev89`\n**WPC**: `0.0.1-dev89`\n**EM**: `0.0.1-dev89`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-05T15:30:41+00:00",
-    "type": "dev",
-    "download_count": 5
+    "type": "dev"
   },
   {
     "version": "0.0.1-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev91`\n**Sys11**: `1.4.0-dev91`\n**WPC**: `0.0.1-dev91`\n**EM**: `0.0.1-dev91`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T19:03:49+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "0.0.1-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev90`\n**Sys11**: `1.4.0-dev90`\n**WPC**: `0.0.1-dev90`\n**EM**: `0.0.1-dev90`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-08T18:50:19+00:00",
-    "type": "dev",
-    "download_count": 3
+    "type": "dev"
   },
   {
     "version": "0.0.2-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
     "notes": "## Versions\n**Vector**: `1.3.11-dev92`\n**Sys11**: `1.4.0-dev92`\n**WPC**: `0.0.2-dev92`\n**EM**: `0.0.1-dev92`\n<!-- END VERSIONS SECTION -->",
     "published_at": "2025-07-12T22:23:49+00:00",
-    "type": "dev",
-    "download_count": 0
+    "type": "dev"
   }
 ]

--- a/docs/vector/wpc/latest.json
+++ b/docs/vector/wpc/latest.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.2-beta493",
   "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-  "release_page": "https://github.com/warped-pinball/vector/releases/tag/0.0.2-beta493",
+  "release_page": "https://github.com/warped-pinball/vector/releases/tag/1.3.11-beta493",
   "notes": "## Versions\n**Vector**: `1.3.11-beta493`\n**Sys11**: `1.4.0-beta493`\n**WPC**: `0.0.2-beta493`\n**EM**: `0.0.1-beta493`\n<!-- END VERSIONS SECTION -->",
   "published_at": "2025-07-18T20:12:57+00:00"
 }

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -68,3 +68,41 @@ def test_parse_release_versions_missing():
     body = "No version info"
     versions = generate.parse_release_versions(body)
     assert versions == {}
+
+
+def test_build_latest_release_data_uses_tag():
+    entry = {
+        "version": "0.0.2-beta493",
+        "tag": "1.3.11-beta493",
+        "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
+        "notes": "notes",
+        "published_at": "2025-07-18T20:12:57+00:00",
+    }
+
+    result = generate.build_latest_release_data("warped-pinball", "vector", entry)
+    assert result["release_page"].endswith("/releases/tag/1.3.11-beta493")
+    assert result["version"] == entry["version"]
+
+
+def test_build_file_entry_and_download_record():
+    file_entry = generate.build_file_entry(
+        "sys11",
+        "1.0.0",
+        "prod",
+        "https://example.com/update.json",
+        "deadbeef",
+    )
+
+    download_entry = generate.build_download_record(
+        "sys11",
+        "1.0.0",
+        "prod",
+        "https://example.com/update.json",
+        42,
+    )
+
+    assert "download_count" not in file_entry
+    assert download_entry["download_count"] == 42
+    assert file_entry["sha256"] == "deadbeef"
+
+


### PR DESCRIPTION
## Summary
- fix release_page value for latest WPC release
- track release tag when generating JSON data
- add helper to build latest release metadata
- test new helper
- store download counts in a new download_counts.json file

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7b76014c83308d3bde59e879b686