### PR TITLE
Sanitize release notes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: [--max-line-length=88, --extend-ignore=E203]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 PyGithub>=2.2.0
 requests>=2.31.0
+markdown>=3.4
+bleach>=6.0

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,11 +2,12 @@ import json
 import os
 import sys
 
-import pytest
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-import scripts.generate as generate
+import scripts.generate as generate  # noqa: E402
 
 
 def test_calculate_json_hash_deterministic():
@@ -68,3 +69,11 @@ def test_parse_release_versions_missing():
     body = "No version info"
     versions = generate.parse_release_versions(body)
     assert versions == {}
+
+
+def test_release_notes_to_html_sanitizes_and_strips_images():
+    md = "Hello! ![img](http://example.com/a.png) <script>alert('x')</script>"
+    html = generate.release_notes_to_html(md)
+    assert "<img" not in html
+    assert "script" not in html
+    assert "Hello" in html


### PR DESCRIPTION
## Summary
- convert GitHub release notes markdown to sanitized HTML
- strip image tags from release notes
- test new sanitization logic
- add dependencies for markdown and bleach
- disallow img tags via bleach
- setup and run pre-commit

## Testing
- `pre-commit run --files scripts/generate.py tests/test_generate.py .pre-commit-config.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a7cdf1b008330948d00107c08ca1c