### PR TITLE
Fix markdown newline rendering

### DIFF
--- a/docs/download_counts.json
+++ b/docs/download_counts.json
@@ -4,1126 +4,1126 @@
     "version": "0.4.0-dev24",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev22",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev25",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.3.0-beta-116",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta123",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta126",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev28",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta130",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.4.2-dev30",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.4.1-beta135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev31",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.4.2-beta139",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev32",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.4.3-beta145",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev35",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.4.5-dev33",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev34",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta149",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev43",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta203",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev45",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev46",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev44",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta211",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta225",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.1.0-beta227",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev51",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev50",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta235",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta246",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta251",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta254",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev54",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta258",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev57",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev61",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.1-beta310",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta320",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta319",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev62",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta324",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta327",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev63",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.3-beta330",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev66",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev65",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta338",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev70",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta358",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta361",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
-    "download_count": 197
+    "download_count": 198
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta363",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta372",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta376",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.7-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta378",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev74",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.3.7",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
-    "download_count": 146
+    "download_count": 147
   },
   {
     "product": "sys11",
     "version": "1.3.7-beta381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.3.8",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev78",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev77",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev76",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta386",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta394",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev80",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta396",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev81",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta399",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.9",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev82",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta404",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta408",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.3.10",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.3.10-beta419",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "download_count": 5
+    "download_count": 6
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "download_count": 6
+    "download_count": 7
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "download_count": 8
+    "download_count": 9
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update.json",
-    "download_count": 5
+    "download_count": 6
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_wpc.json",
-    "download_count": 6
+    "download_count": 7
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "download_count": 6
+    "download_count": 7
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "download_count": 7
+    "download_count": 8
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update.json",
-    "download_count": 5
+    "download_count": 6
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_wpc.json",
-    "download_count": 5
+    "download_count": 6
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update.json",
-    "download_count": 4
+    "download_count": 5
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_wpc.json",
-    "download_count": 4
+    "download_count": 5
   }
 ]

--- a/docs/vector/sys11/all.json
+++ b/docs/vector/sys11/all.json
@@ -3,7 +3,7 @@
     "version": "0.4.0-dev24",
     "tag": "0.4.0-dev24",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/24\nBranch: pre-commit-changes\nVersion: 0.4.0-dev24</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/24<br>\nBranch: pre-commit-changes<br>\nVersion: 0.4.0-dev24</p>",
     "published_at": "2025-01-19T22:45:30+00:00",
     "type": "dev"
   },
@@ -11,7 +11,7 @@
     "version": "0.4.0-dev22",
     "tag": "0.4.0-dev22",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/22\nBranch: Serial_Flash_Test\nVersion: 0.4.0-dev22</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/22<br>\nBranch: Serial_Flash_Test<br>\nVersion: 0.4.0-dev22</p>",
     "published_at": "2025-01-19T03:00:13+00:00",
     "type": "dev"
   },
@@ -27,7 +27,7 @@
     "version": "0.4.0-dev25",
     "tag": "0.4.0-dev25",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/25\nBranch: network-discovery\nVersion: 0.4.0-dev25</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/25<br>\nBranch: network-discovery<br>\nVersion: 0.4.0-dev25</p>",
     "published_at": "2025-01-26T19:37:25+00:00",
     "type": "dev"
   },
@@ -35,7 +35,7 @@
     "version": "0.3.0-beta-116",
     "tag": "0.3.0-beta-116",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.3.0-beta-116</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.3.0-beta-116</p>",
     "published_at": "2025-01-26T17:00:14+00:00",
     "type": "beta"
   },
@@ -43,7 +43,7 @@
     "version": "0.4.0-beta123",
     "tag": "0.4.0-beta123",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.0-beta123</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.0-beta123</p>",
     "published_at": "2025-01-28T22:23:22+00:00",
     "type": "beta"
   },
@@ -51,7 +51,7 @@
     "version": "0.4.0-beta126",
     "tag": "0.4.0-beta126",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.0-beta126</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.0-beta126</p>",
     "published_at": "2025-01-28T23:32:55+00:00",
     "type": "beta"
   },
@@ -59,7 +59,7 @@
     "version": "0.4.1-dev28",
     "tag": "0.4.1-dev28",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/28\nBranch: cancel-button-fix\nVersion: 0.4.1-dev28</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/28<br>\nBranch: cancel-button-fix<br>\nVersion: 0.4.1-dev28</p>",
     "published_at": "2025-02-01T23:38:40+00:00",
     "type": "dev"
   },
@@ -67,7 +67,7 @@
     "version": "0.4.0-dev29",
     "tag": "0.4.0-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.0-dev29</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29<br>\nBranch: scores<br>\nVersion: 0.4.0-dev29</p>",
     "published_at": "2025-02-01T23:42:13+00:00",
     "type": "dev"
   },
@@ -75,7 +75,7 @@
     "version": "0.4.0-beta130",
     "tag": "0.4.0-beta130",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.0-beta130</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.0-beta130</p>",
     "published_at": "2025-02-01T23:36:46+00:00",
     "type": "beta"
   },
@@ -83,7 +83,7 @@
     "version": "0.4.2-dev30",
     "tag": "0.4.2-dev30",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/30\nBranch: no-discovery-in-ap-mode\nVersion: 0.4.2-dev30</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/30<br>\nBranch: no-discovery-in-ap-mode<br>\nVersion: 0.4.2-dev30</p>",
     "published_at": "2025-02-02T02:53:34+00:00",
     "type": "dev"
   },
@@ -91,7 +91,7 @@
     "version": "0.4.1-dev29",
     "tag": "0.4.1-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.1-dev29</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29<br>\nBranch: scores<br>\nVersion: 0.4.1-dev29</p>",
     "published_at": "2025-02-01T23:49:39+00:00",
     "type": "dev"
   },
@@ -99,7 +99,7 @@
     "version": "0.4.1-beta135",
     "tag": "0.4.1-beta135",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.1-beta135</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.1-beta135</p>",
     "published_at": "2025-02-01T23:48:13+00:00",
     "type": "beta"
   },
@@ -107,7 +107,7 @@
     "version": "0.4.3-dev31",
     "tag": "0.4.3-dev31",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/31\nBranch: authenticate-for-logs\nVersion: 0.4.3-dev31</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/31<br>\nBranch: authenticate-for-logs<br>\nVersion: 0.4.3-dev31</p>",
     "published_at": "2025-02-02T16:34:19+00:00",
     "type": "dev"
   },
@@ -115,7 +115,7 @@
     "version": "0.4.3-dev29",
     "tag": "0.4.3-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.3-dev29</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29<br>\nBranch: scores<br>\nVersion: 0.4.3-dev29</p>",
     "published_at": "2025-02-02T03:21:43+00:00",
     "type": "dev"
   },
@@ -123,7 +123,7 @@
     "version": "0.4.2-beta139",
     "tag": "0.4.2-beta139",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.2-beta139</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.2-beta139</p>",
     "published_at": "2025-02-02T03:06:44+00:00",
     "type": "beta"
   },
@@ -131,7 +131,7 @@
     "version": "0.4.4-dev32",
     "tag": "0.4.4-dev32",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/32\nBranch: main_0_4_0_testing\nVersion: 0.4.4-dev32</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/32<br>\nBranch: main_0_4_0_testing<br>\nVersion: 0.4.4-dev32</p>",
     "published_at": "2025-02-03T21:50:24+00:00",
     "type": "dev"
   },
@@ -139,7 +139,7 @@
     "version": "0.4.3-beta145",
     "tag": "0.4.3-beta145",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.3-beta145</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.3-beta145</p>",
     "published_at": "2025-02-02T16:46:59+00:00",
     "type": "beta"
   },
@@ -147,7 +147,7 @@
     "version": "1.0.0-dev35",
     "tag": "1.0.0-dev35",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/35\nBranch: update-logic-fix\nVersion: 1.0.0-dev35</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/35<br>\nBranch: update-logic-fix<br>\nVersion: 1.0.0-dev35</p>",
     "published_at": "2025-02-06T04:13:37+00:00",
     "type": "dev"
   },
@@ -155,7 +155,7 @@
     "version": "0.4.5-dev33",
     "tag": "0.4.5-dev33",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/33\nBranch: KISS-scores\nVersion: 0.4.5-dev33</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/33<br>\nBranch: KISS-scores<br>\nVersion: 0.4.5-dev33</p>",
     "published_at": "2025-02-05T04:13:36+00:00",
     "type": "dev"
   },
@@ -163,7 +163,7 @@
     "version": "0.4.4-dev34",
     "tag": "0.4.4-dev34",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/34\nBranch: Factory-Reset\nVersion: 0.4.4-dev34</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/34<br>\nBranch: Factory-Reset<br>\nVersion: 0.4.4-dev34</p>",
     "published_at": "2025-02-05T19:53:48+00:00",
     "type": "dev"
   },
@@ -171,7 +171,7 @@
     "version": "0.4.4-beta149",
     "tag": "0.4.4-beta149",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.4-beta149</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.4-beta149</p>",
     "published_at": "2025-02-04T01:02:49+00:00",
     "type": "beta"
   },
@@ -187,7 +187,7 @@
     "version": "0.4.4-beta160",
     "tag": "0.4.4-beta160",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.4-beta160</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.4-beta160</p>",
     "published_at": "2025-02-06T22:57:10+00:00",
     "type": "beta"
   },
@@ -203,7 +203,7 @@
     "version": "1.0.0-dev43",
     "tag": "1.0.0-dev43",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/43\nBranch: memory-efficiency\nVersion: 1.0.0-dev43</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/43<br>\nBranch: memory-efficiency<br>\nVersion: 1.0.0-dev43</p>",
     "published_at": "2025-02-25T02:49:28+00:00",
     "type": "dev"
   },
@@ -211,7 +211,7 @@
     "version": "1.0.0-beta203",
     "tag": "1.0.0-beta203",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.0.0-beta203</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.0.0-beta203</p>",
     "published_at": "2025-02-23T19:57:39+00:00",
     "type": "beta"
   },
@@ -219,7 +219,7 @@
     "version": "1.1.0-dev45",
     "tag": "1.1.0-dev45",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/45\nBranch: wifi-reconnect\nVersion: 1.1.0-dev45</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/45<br>\nBranch: wifi-reconnect<br>\nVersion: 1.1.0-dev45</p>",
     "published_at": "2025-02-26T03:22:37+00:00",
     "type": "dev"
   },
@@ -227,7 +227,7 @@
     "version": "1.0.0-dev47",
     "tag": "1.0.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.0.0-dev47</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47<br>\nBranch: live-scores-webui<br>\nVersion: 1.0.0-dev47</p>",
     "published_at": "2025-02-26T23:04:19+00:00",
     "type": "dev"
   },
@@ -235,7 +235,7 @@
     "version": "1.0.0-dev46",
     "tag": "1.0.0-dev46",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/46\nBranch: logging\nVersion: 1.0.0-dev46</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/46<br>\nBranch: logging<br>\nVersion: 1.0.0-dev46</p>",
     "published_at": "2025-02-26T03:36:54+00:00",
     "type": "dev"
   },
@@ -243,7 +243,7 @@
     "version": "1.0.0-dev44",
     "tag": "1.0.0-dev44",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/44\nBranch: memory-efficiency\nVersion: 1.0.0-dev44</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/44<br>\nBranch: memory-efficiency<br>\nVersion: 1.0.0-dev44</p>",
     "published_at": "2025-02-26T01:38:58+00:00",
     "type": "dev"
   },
@@ -251,7 +251,7 @@
     "version": "1.0.0-beta211",
     "tag": "1.0.0-beta211",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.0.0-beta211</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.0.0-beta211</p>",
     "published_at": "2025-02-26T01:31:32+00:00",
     "type": "beta"
   },
@@ -259,7 +259,7 @@
     "version": "1.0.0-beta225",
     "tag": "1.0.0-beta225",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.0.0-beta225</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.0.0-beta225</p>",
     "published_at": "2025-03-01T01:37:48+00:00",
     "type": "beta"
   },
@@ -267,7 +267,7 @@
     "version": "1.2.0-dev47",
     "tag": "1.2.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.2.0-dev47</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47<br>\nBranch: live-scores-webui<br>\nVersion: 1.2.0-dev47</p>",
     "published_at": "2025-03-01T01:45:10+00:00",
     "type": "dev"
   },
@@ -283,7 +283,7 @@
     "version": "1.1.0-dev49",
     "tag": "1.1.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.1.0-dev49</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49<br>\nBranch: discovery-recovery<br>\nVersion: 1.1.0-dev49</p>",
     "published_at": "2025-03-02T01:58:59+00:00",
     "type": "dev"
   },
@@ -291,7 +291,7 @@
     "version": "1.1.0-dev48",
     "tag": "1.1.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.1.0-dev48</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48<br>\nBranch: fix-overlapping-routes<br>\nVersion: 1.1.0-dev48</p>",
     "published_at": "2025-03-02T01:31:46+00:00",
     "type": "dev"
   },
@@ -299,7 +299,7 @@
     "version": "1.1.0-beta227",
     "tag": "1.1.0-beta227",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.1.0-beta227</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.1.0-beta227</p>",
     "published_at": "2025-03-01T01:39:02+00:00",
     "type": "beta"
   },
@@ -315,7 +315,7 @@
     "version": "1.2.0-dev53",
     "tag": "1.2.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.2.0-dev53</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53<br>\nBranch: disaplymessage_robusto<br>\nVersion: 1.2.0-dev53</p>",
     "published_at": "2025-03-02T13:11:53+00:00",
     "type": "dev"
   },
@@ -323,7 +323,7 @@
     "version": "1.2.0-dev52",
     "tag": "1.2.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.2.0-dev52</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52<br>\nBranch: js-linter<br>\nVersion: 1.2.0-dev52</p>",
     "published_at": "2025-03-02T04:43:50+00:00",
     "type": "dev"
   },
@@ -331,7 +331,7 @@
     "version": "1.2.0-dev51",
     "tag": "1.2.0-dev51",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/51\nBranch: show-ip-toggle\nVersion: 1.2.0-dev51</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/51<br>\nBranch: show-ip-toggle<br>\nVersion: 1.2.0-dev51</p>",
     "published_at": "2025-03-02T02:47:20+00:00",
     "type": "dev"
   },
@@ -339,7 +339,7 @@
     "version": "1.2.0-dev50",
     "tag": "1.2.0-dev50",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/50\nBranch: web-ui-claim-toggle\nVersion: 1.2.0-dev50</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/50<br>\nBranch: web-ui-claim-toggle<br>\nVersion: 1.2.0-dev50</p>",
     "published_at": "2025-03-02T02:15:04+00:00",
     "type": "dev"
   },
@@ -347,7 +347,7 @@
     "version": "1.2.0-dev49",
     "tag": "1.2.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.2.0-dev49</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49<br>\nBranch: discovery-recovery<br>\nVersion: 1.2.0-dev49</p>",
     "published_at": "2025-03-02T02:20:30+00:00",
     "type": "dev"
   },
@@ -355,7 +355,7 @@
     "version": "1.2.0-dev48",
     "tag": "1.2.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.2.0-dev48</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48<br>\nBranch: fix-overlapping-routes<br>\nVersion: 1.2.0-dev48</p>",
     "published_at": "2025-03-02T02:20:00+00:00",
     "type": "dev"
   },
@@ -363,7 +363,7 @@
     "version": "1.2.0-beta235",
     "tag": "1.2.0-beta235",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta235</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta235</p>",
     "published_at": "2025-03-02T02:11:41+00:00",
     "type": "beta"
   },
@@ -371,7 +371,7 @@
     "version": "1.2.0-beta246",
     "tag": "1.2.0-beta246",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta246</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta246</p>",
     "published_at": "2025-03-02T15:06:22+00:00",
     "type": "beta"
   },
@@ -379,7 +379,7 @@
     "version": "1.2.0-beta247",
     "tag": "1.2.0-beta247",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta247</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta247</p>",
     "published_at": "2025-03-02T15:06:45+00:00",
     "type": "beta"
   },
@@ -387,7 +387,7 @@
     "version": "1.2.0-beta251",
     "tag": "1.2.0-beta251",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta251</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta251</p>",
     "published_at": "2025-03-02T17:51:26+00:00",
     "type": "beta"
   },
@@ -395,7 +395,7 @@
     "version": "1.3.0-dev52",
     "tag": "1.3.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.3.0-dev52</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52<br>\nBranch: js-linter<br>\nVersion: 1.3.0-dev52</p>",
     "published_at": "2025-03-02T18:26:23+00:00",
     "type": "dev"
   },
@@ -403,7 +403,7 @@
     "version": "1.2.0-beta254",
     "tag": "1.2.0-beta254",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta254</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta254</p>",
     "published_at": "2025-03-02T18:14:40+00:00",
     "type": "beta"
   },
@@ -411,7 +411,7 @@
     "version": "1.3.0-dev55",
     "tag": "1.3.0-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.0-dev55</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55<br>\nBranch: Testing-and-bug-resolution<br>\nVersion: 1.3.0-dev55</p>",
     "published_at": "2025-03-03T00:14:20+00:00",
     "type": "dev"
   },
@@ -419,7 +419,7 @@
     "version": "1.3.0-dev54",
     "tag": "1.3.0-dev54",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/54\nBranch: route-quick-fix\nVersion: 1.3.0-dev54</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/54<br>\nBranch: route-quick-fix<br>\nVersion: 1.3.0-dev54</p>",
     "published_at": "2025-03-02T23:21:53+00:00",
     "type": "dev"
   },
@@ -427,7 +427,7 @@
     "version": "1.3.0-dev53",
     "tag": "1.3.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.0-dev53</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53<br>\nBranch: disaplymessage_robusto<br>\nVersion: 1.3.0-dev53</p>",
     "published_at": "2025-03-02T19:21:48+00:00",
     "type": "dev"
   },
@@ -435,7 +435,7 @@
     "version": "1.3.0-beta258",
     "tag": "1.3.0-beta258",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.0-beta258</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.0-beta258</p>",
     "published_at": "2025-03-02T18:46:18+00:00",
     "type": "beta"
   },
@@ -443,7 +443,7 @@
     "version": "1.3.1-dev58",
     "tag": "1.3.1-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.1-dev58</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58<br>\nBranch: KISS-scores-reload<br>\nVersion: 1.3.1-dev58</p>",
     "published_at": "2025-03-06T04:10:33+00:00",
     "type": "dev"
   },
@@ -451,7 +451,7 @@
     "version": "1.3.1-dev55",
     "tag": "1.3.1-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.1-dev55</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55<br>\nBranch: Testing-and-bug-resolution<br>\nVersion: 1.3.1-dev55</p>",
     "published_at": "2025-03-06T21:14:36+00:00",
     "type": "dev"
   },
@@ -459,7 +459,7 @@
     "version": "1.3.0-dev59",
     "tag": "1.3.0-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.0-dev59</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59<br>\nBranch: sort-tournament-by-game<br>\nVersion: 1.3.0-dev59</p>",
     "published_at": "2025-03-08T01:01:04+00:00",
     "type": "dev"
   },
@@ -467,7 +467,7 @@
     "version": "1.3.0-dev57",
     "tag": "1.3.0-dev57",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/57\nBranch: combine-api-routes\nVersion: 1.3.0-dev57</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/57<br>\nBranch: combine-api-routes<br>\nVersion: 1.3.0-dev57</p>",
     "published_at": "2025-03-04T03:52:39+00:00",
     "type": "dev"
   },
@@ -475,7 +475,7 @@
     "version": "1.3.0-dev56",
     "tag": "1.3.0-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.0-dev56</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56<br>\nBranch: automated-testing<br>\nVersion: 1.3.0-dev56</p>",
     "published_at": "2025-03-03T02:31:26+00:00",
     "type": "dev"
   },
@@ -483,7 +483,7 @@
     "version": "1.3.0-beta262",
     "tag": "1.3.0-beta262",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.0-beta262</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.0-beta262</p>",
     "published_at": "2025-03-03T02:26:06+00:00",
     "type": "beta"
   },
@@ -491,7 +491,7 @@
     "version": "1.3.2-dev61",
     "tag": "1.3.2-dev61",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/61\nBranch: light-mode-style-fixes\nVersion: 1.3.2-dev61</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/61<br>\nBranch: light-mode-style-fixes<br>\nVersion: 1.3.2-dev61</p>",
     "published_at": "2025-03-09T17:10:25+00:00",
     "type": "dev"
   },
@@ -499,7 +499,7 @@
     "version": "1.3.2-dev60",
     "tag": "1.3.2-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.2-dev60</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60<br>\nBranch: claim-in-tournament<br>\nVersion: 1.3.2-dev60</p>",
     "published_at": "2025-03-09T01:49:28+00:00",
     "type": "dev"
   },
@@ -515,7 +515,7 @@
     "version": "1.3.1-dev60",
     "tag": "1.3.1-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.1-dev60</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60<br>\nBranch: claim-in-tournament<br>\nVersion: 1.3.1-dev60</p>",
     "published_at": "2025-03-08T04:07:36+00:00",
     "type": "dev"
   },
@@ -523,7 +523,7 @@
     "version": "1.3.1-dev59",
     "tag": "1.3.1-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.1-dev59</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59<br>\nBranch: sort-tournament-by-game<br>\nVersion: 1.3.1-dev59</p>",
     "published_at": "2025-03-09T17:25:13+00:00",
     "type": "dev"
   },
@@ -531,7 +531,7 @@
     "version": "1.3.1-dev56",
     "tag": "1.3.1-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.1-dev56</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56<br>\nBranch: automated-testing<br>\nVersion: 1.3.1-dev56</p>",
     "published_at": "2025-03-09T17:13:13+00:00",
     "type": "dev"
   },
@@ -539,7 +539,7 @@
     "version": "1.3.1-beta310",
     "tag": "1.3.1-beta310",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.1-beta310</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.1-beta310</p>",
     "published_at": "2025-03-08T01:30:28+00:00",
     "type": "beta"
   },
@@ -547,7 +547,7 @@
     "version": "1.3.2-dev58",
     "tag": "1.3.2-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.2-dev58</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58<br>\nBranch: KISS-scores-reload<br>\nVersion: 1.3.2-dev58</p>",
     "published_at": "2025-03-09T17:26:50+00:00",
     "type": "dev"
   },
@@ -555,7 +555,7 @@
     "version": "1.3.2-dev53",
     "tag": "1.3.2-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.2-dev53</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53<br>\nBranch: disaplymessage_robusto<br>\nVersion: 1.3.2-dev53</p>",
     "published_at": "2025-03-09T17:29:06+00:00",
     "type": "dev"
   },
@@ -563,7 +563,7 @@
     "version": "1.3.2-beta320",
     "tag": "1.3.2-beta320",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta320</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta320</p>",
     "published_at": "2025-03-09T17:26:29+00:00",
     "type": "beta"
   },
@@ -571,7 +571,7 @@
     "version": "1.3.2-beta319",
     "tag": "1.3.2-beta319",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta319</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta319</p>",
     "published_at": "2025-03-09T17:26:07+00:00",
     "type": "beta"
   },
@@ -587,7 +587,7 @@
     "version": "1.3.2-dev62",
     "tag": "1.3.2-dev62",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/62\nBranch: short-initials\nVersion: 1.3.2-dev62</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/62<br>\nBranch: short-initials<br>\nVersion: 1.3.2-dev62</p>",
     "published_at": "2025-03-09T20:17:00+00:00",
     "type": "dev"
   },
@@ -595,7 +595,7 @@
     "version": "1.3.2-beta324",
     "tag": "1.3.2-beta324",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta324</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta324</p>",
     "published_at": "2025-03-09T17:33:04+00:00",
     "type": "beta"
   },
@@ -603,7 +603,7 @@
     "version": "1.3.2-beta327",
     "tag": "1.3.2-beta327",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta327</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta327</p>",
     "published_at": "2025-03-09T21:49:26+00:00",
     "type": "beta"
   },
@@ -611,7 +611,7 @@
     "version": "1.3.4-dev64",
     "tag": "1.3.4-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.4-dev64</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64<br>\nBranch: log-adjustments<br>\nVersion: 1.3.4-dev64</p>",
     "published_at": "2025-03-12T02:36:22+00:00",
     "type": "dev"
   },
@@ -627,7 +627,7 @@
     "version": "1.3.3-dev64",
     "tag": "1.3.3-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.3-dev64</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64<br>\nBranch: log-adjustments<br>\nVersion: 1.3.3-dev64</p>",
     "published_at": "2025-03-10T22:27:24+00:00",
     "type": "dev"
   },
@@ -635,7 +635,7 @@
     "version": "1.3.3-dev63",
     "tag": "1.3.3-dev63",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/63\nBranch: version-bump\nVersion: 1.3.3-dev63</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/63<br>\nBranch: version-bump<br>\nVersion: 1.3.3-dev63</p>",
     "published_at": "2025-03-09T21:51:53+00:00",
     "type": "dev"
   },
@@ -643,7 +643,7 @@
     "version": "1.3.3-beta330",
     "tag": "1.3.3-beta330",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.3-beta330</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.3-beta330</p>",
     "published_at": "2025-03-09T21:51:50+00:00",
     "type": "beta"
   },
@@ -659,7 +659,7 @@
     "version": "1.3.4-dev68",
     "tag": "1.3.4-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.4-dev68</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68<br>\nBranch: live-scores-clear<br>\nVersion: 1.3.4-dev68</p>",
     "published_at": "2025-03-22T14:42:01+00:00",
     "type": "dev"
   },
@@ -667,7 +667,7 @@
     "version": "1.3.4-dev67",
     "tag": "1.3.4-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.4-dev67</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67<br>\nBranch: diner_fix<br>\nVersion: 1.3.4-dev67</p>",
     "published_at": "2025-03-21T01:50:43+00:00",
     "type": "dev"
   },
@@ -675,7 +675,7 @@
     "version": "1.3.4-dev66",
     "tag": "1.3.4-dev66",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/66\nBranch: improved-readme\nVersion: 1.3.4-dev66</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/66<br>\nBranch: improved-readme<br>\nVersion: 1.3.4-dev66</p>",
     "published_at": "2025-03-20T03:50:27+00:00",
     "type": "dev"
   },
@@ -683,7 +683,7 @@
     "version": "1.3.4-dev65",
     "tag": "1.3.4-dev65",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/65\nBranch: Zoom-Demo-TPF\nVersion: 1.3.4-dev65</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/65<br>\nBranch: Zoom-Demo-TPF<br>\nVersion: 1.3.4-dev65</p>",
     "published_at": "2025-03-14T20:48:15+00:00",
     "type": "dev"
   },
@@ -691,7 +691,7 @@
     "version": "1.3.4-beta338",
     "tag": "1.3.4-beta338",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.4-beta338</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.4-beta338</p>",
     "published_at": "2025-03-12T02:36:53+00:00",
     "type": "beta"
   },
@@ -699,7 +699,7 @@
     "version": "1.3.5-dev70",
     "tag": "1.3.5-dev70",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/70\nBranch: version-bump\nVersion: 1.3.5-dev70</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/70<br>\nBranch: version-bump<br>\nVersion: 1.3.5-dev70</p>",
     "published_at": "2025-03-23T20:42:40+00:00",
     "type": "dev"
   },
@@ -707,7 +707,7 @@
     "version": "1.3.4-beta358",
     "tag": "1.3.4-beta358",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.4-beta358</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.4-beta358</p>",
     "published_at": "2025-03-22T20:32:57+00:00",
     "type": "beta"
   },
@@ -715,7 +715,7 @@
     "version": "1.3.5-dev67",
     "tag": "1.3.5-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.5-dev67</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67<br>\nBranch: diner_fix<br>\nVersion: 1.3.5-dev67</p>",
     "published_at": "2025-03-23T20:50:37+00:00",
     "type": "dev"
   },
@@ -723,7 +723,7 @@
     "version": "1.3.5-beta361",
     "tag": "1.3.5-beta361",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.5-beta361</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.5-beta361</p>",
     "published_at": "2025-03-23T20:44:01+00:00",
     "type": "beta"
   },
@@ -731,7 +731,7 @@
     "version": "1.3.6-dev68",
     "tag": "1.3.6-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.6-dev68</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68<br>\nBranch: live-scores-clear<br>\nVersion: 1.3.6-dev68</p>",
     "published_at": "2025-03-27T19:29:06+00:00",
     "type": "dev"
   },
@@ -747,7 +747,7 @@
     "version": "1.3.5-dev68",
     "tag": "1.3.5-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.5-dev68</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68<br>\nBranch: live-scores-clear<br>\nVersion: 1.3.5-dev68</p>",
     "published_at": "2025-03-27T00:43:16+00:00",
     "type": "dev"
   },
@@ -755,7 +755,7 @@
     "version": "1.3.5-beta363",
     "tag": "1.3.5-beta363",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.5-beta363</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.5-beta363</p>",
     "published_at": "2025-03-23T20:51:10+00:00",
     "type": "beta"
   },
@@ -763,7 +763,7 @@
     "version": "1.3.5-dev72",
     "tag": "1.3.5-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.5-dev72</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72<br>\nBranch: readme-contributors<br>\nVersion: 1.3.5-dev72</p>",
     "published_at": "2025-03-28T00:09:24+00:00",
     "type": "dev"
   },
@@ -771,7 +771,7 @@
     "version": "1.3.5-beta372",
     "tag": "1.3.5-beta372",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.5-beta372</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.5-beta372</p>",
     "published_at": "2025-03-27T23:54:32+00:00",
     "type": "beta"
   },
@@ -779,7 +779,7 @@
     "version": "1.3.6-beta376",
     "tag": "1.3.6-beta376",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.6-beta376</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.6-beta376</p>",
     "published_at": "2025-03-28T00:12:27+00:00",
     "type": "beta"
   },
@@ -787,7 +787,7 @@
     "version": "1.3.7-dev73",
     "tag": "1.3.7-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.7-dev73</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73<br>\nBranch: Space-Station-Fix<br>\nVersion: 1.3.7-dev73</p>",
     "published_at": "2025-04-01T00:04:20+00:00",
     "type": "dev"
   },
@@ -795,7 +795,7 @@
     "version": "1.3.6-dev73",
     "tag": "1.3.6-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.6-dev73</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73<br>\nBranch: Space-Station-Fix<br>\nVersion: 1.3.6-dev73</p>",
     "published_at": "2025-04-01T00:03:22+00:00",
     "type": "dev"
   },
@@ -803,7 +803,7 @@
     "version": "1.3.6-dev72",
     "tag": "1.3.6-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.6-dev72</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72<br>\nBranch: readme-contributors<br>\nVersion: 1.3.6-dev72</p>",
     "published_at": "2025-03-28T00:12:53+00:00",
     "type": "dev"
   },
@@ -811,7 +811,7 @@
     "version": "1.3.6-beta378",
     "tag": "1.3.6-beta378",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.6-beta378</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.6-beta378</p>",
     "published_at": "2025-03-28T00:13:00+00:00",
     "type": "beta"
   },
@@ -819,7 +819,7 @@
     "version": "1.3.8-dev74",
     "tag": "1.3.8-dev74",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/74\nBranch: sys9-score-fix\nVersion: 1.3.8-dev74</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/74<br>\nBranch: sys9-score-fix<br>\nVersion: 1.3.8-dev74</p>",
     "published_at": "2025-04-11T17:27:47+00:00",
     "type": "dev"
   },
@@ -835,7 +835,7 @@
     "version": "1.3.7-beta381",
     "tag": "1.3.7-beta381",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.7-beta381</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.7-beta381</p>",
     "published_at": "2025-04-01T00:42:48+00:00",
     "type": "beta"
   },
@@ -851,7 +851,7 @@
     "version": "1.3.8-dev78",
     "tag": "1.3.8-dev78",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/78\nBranch: wifi-retry-timeout\nVersion: 1.3.8-dev78</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/78<br>\nBranch: wifi-retry-timeout<br>\nVersion: 1.3.8-dev78</p>",
     "published_at": "2025-05-03T01:41:00+00:00",
     "type": "dev"
   },
@@ -859,7 +859,7 @@
     "version": "1.3.8-dev77",
     "tag": "1.3.8-dev77",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/77\nBranch: improved-discover\nVersion: 1.3.8-dev77</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/77<br>\nBranch: improved-discover<br>\nVersion: 1.3.8-dev77</p>",
     "published_at": "2025-04-17T21:38:55+00:00",
     "type": "dev"
   },
@@ -867,7 +867,7 @@
     "version": "1.3.8-dev76",
     "tag": "1.3.8-dev76",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/76\nBranch: Sorcerer-add\nVersion: 1.3.8-dev76</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/76<br>\nBranch: Sorcerer-add<br>\nVersion: 1.3.8-dev76</p>",
     "published_at": "2025-04-16T23:34:10+00:00",
     "type": "dev"
   },
@@ -875,7 +875,7 @@
     "version": "1.3.8-beta386",
     "tag": "1.3.8-beta386",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta386</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta386</p>",
     "published_at": "2025-04-11T18:47:45+00:00",
     "type": "beta"
   },
@@ -883,7 +883,7 @@
     "version": "1.3.8-beta394",
     "tag": "1.3.8-beta394",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta394</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta394</p>",
     "published_at": "2025-05-06T00:11:44+00:00",
     "type": "beta"
   },
@@ -891,7 +891,7 @@
     "version": "1.3.8-dev80",
     "tag": "1.3.8-dev80",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/80\nBranch: Whirlwind-Live-Scores\nVersion: 1.3.8-dev80</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/80<br>\nBranch: Whirlwind-Live-Scores<br>\nVersion: 1.3.8-dev80</p>",
     "published_at": "2025-05-20T01:46:42+00:00",
     "type": "dev"
   },
@@ -899,7 +899,7 @@
     "version": "1.3.8-beta396",
     "tag": "1.3.8-beta396",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta396</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta396</p>",
     "published_at": "2025-05-20T00:53:56+00:00",
     "type": "beta"
   },
@@ -907,7 +907,7 @@
     "version": "1.3.9-dev81",
     "tag": "1.3.9-dev81",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/81\nBranch: version-bump\nVersion: 1.3.9-dev81</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/81<br>\nBranch: version-bump<br>\nVersion: 1.3.9-dev81</p>",
     "published_at": "2025-05-21T02:01:22+00:00",
     "type": "dev"
   },
@@ -915,7 +915,7 @@
     "version": "1.3.8-beta399",
     "tag": "1.3.8-beta399",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta399</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta399</p>",
     "published_at": "2025-05-20T02:38:42+00:00",
     "type": "beta"
   },
@@ -931,7 +931,7 @@
     "version": "1.3.9-dev82",
     "tag": "1.3.9-dev82",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/82\nBranch: leader_reset\nVersion: 1.3.9-dev82</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/82<br>\nBranch: leader_reset<br>\nVersion: 1.3.9-dev82</p>",
     "published_at": "2025-05-26T21:08:30+00:00",
     "type": "dev"
   },
@@ -939,7 +939,7 @@
     "version": "1.3.9-beta404",
     "tag": "1.3.9-beta404",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.9-beta404</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.9-beta404</p>",
     "published_at": "2025-05-21T02:04:22+00:00",
     "type": "beta"
   },
@@ -947,7 +947,7 @@
     "version": "1.3.10-dev84",
     "tag": "1.3.10-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.10-dev84</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84<br>\nBranch: Fire-in-play-data<br>\nVersion: 1.3.10-dev84</p>",
     "published_at": "2025-06-18T23:57:48+00:00",
     "type": "dev"
   },
@@ -955,7 +955,7 @@
     "version": "1.3.9-dev84",
     "tag": "1.3.9-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.9-dev84</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84<br>\nBranch: Fire-in-play-data<br>\nVersion: 1.3.9-dev84</p>",
     "published_at": "2025-06-18T23:56:13+00:00",
     "type": "dev"
   },
@@ -963,7 +963,7 @@
     "version": "1.3.9-beta408",
     "tag": "1.3.9-beta408",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.9-beta408</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.9-beta408</p>",
     "published_at": "2025-05-26T22:24:34+00:00",
     "type": "beta"
   },
@@ -971,7 +971,7 @@
     "version": "1.4.0-dev83",
     "tag": "1.3.11-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code>\n<strong>WPC</strong>: <code>0.0.1-dev83</code>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev83</code><br>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
     "published_at": "2025-06-24T01:11:06+00:00",
     "type": "dev"
   },
@@ -987,7 +987,7 @@
     "version": "1.3.10-dev83",
     "tag": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "notes": "<p>Version: 1.3.10-dev83\nTrigger: pull_request</p>",
+    "notes": "<p>Version: 1.3.10-dev83<br>\nTrigger: pull_request</p>",
     "published_at": "2025-06-19T02:25:50+00:00",
     "type": "dev"
   },
@@ -995,7 +995,7 @@
     "version": "1.3.10-beta419",
     "tag": "1.3.10-beta419",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.10-beta419</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.10-beta419</p>",
     "published_at": "2025-06-19T00:22:15+00:00",
     "type": "beta"
   },
@@ -1003,7 +1003,7 @@
     "version": "1.4.0-dev89",
     "tag": "1.3.11-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code>\n<strong>WPC</strong>: <code>0.0.1-dev89</code>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev89</code><br>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
     "published_at": "2025-07-05T15:30:41+00:00",
     "type": "dev"
   },
@@ -1011,7 +1011,7 @@
     "version": "1.4.0-beta479",
     "tag": "1.3.11-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code>\n<strong>WPC</strong>: <code>0.0.1-beta479</code>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta479</code><br>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
     "published_at": "2025-07-05T15:07:23+00:00",
     "type": "beta"
   },
@@ -1019,7 +1019,7 @@
     "version": "1.4.0-dev91",
     "tag": "1.3.11-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code>\n<strong>WPC</strong>: <code>0.0.1-dev91</code>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev91</code><br>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
     "published_at": "2025-07-08T19:03:49+00:00",
     "type": "dev"
   },
@@ -1027,7 +1027,7 @@
     "version": "1.4.0-dev90",
     "tag": "1.3.11-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code>\n<strong>WPC</strong>: <code>0.0.1-dev90</code>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev90</code><br>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
     "published_at": "2025-07-08T18:50:19+00:00",
     "type": "dev"
   },
@@ -1035,7 +1035,7 @@
     "version": "1.4.0-beta481",
     "tag": "1.3.11-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code>\n<strong>WPC</strong>: <code>0.0.1-beta481</code>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta481</code><br>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
     "published_at": "2025-07-05T16:17:59+00:00",
     "type": "beta"
   },
@@ -1043,7 +1043,7 @@
     "version": "1.4.0-dev92",
     "tag": "1.3.11-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code>\n<strong>WPC</strong>: <code>0.0.2-dev92</code>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev92</code><br>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
     "published_at": "2025-07-12T22:23:49+00:00",
     "type": "dev"
   },
@@ -1051,7 +1051,7 @@
     "version": "1.4.0-beta486",
     "tag": "1.3.11-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code>\n<strong>WPC</strong>: <code>0.0.1-beta486</code>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta486</code><br>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
     "published_at": "2025-07-08T22:43:34+00:00",
     "type": "beta"
   },
@@ -1059,7 +1059,7 @@
     "version": "1.4.1-dev93",
     "tag": "1.3.12-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code>\n<strong>WPC</strong>: <code>0.0.3-dev93</code>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev93</code><br>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
     "published_at": "2025-07-22T01:56:25+00:00",
     "type": "dev"
   },
@@ -1067,7 +1067,7 @@
     "version": "1.4.0-dev96",
     "tag": "1.3.11-dev96",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code>\n<strong>WPC</strong>: <code>0.0.2-dev96</code>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev96</code><br>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
     "published_at": "2025-07-25T03:12:55+00:00",
     "type": "dev"
   },
@@ -1075,7 +1075,7 @@
     "version": "1.4.0-dev95",
     "tag": "1.3.11-dev95",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code>\n<strong>WPC</strong>: <code>0.0.2-dev95</code>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev95</code><br>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
     "published_at": "2025-07-22T13:36:02+00:00",
     "type": "dev"
   },
@@ -1083,7 +1083,7 @@
     "version": "1.4.0-dev94",
     "tag": "1.3.11-dev94",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code>\n<strong>WPC</strong>: <code>0.0.2-dev94</code>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev94</code><br>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
     "published_at": "2025-07-22T13:20:11+00:00",
     "type": "dev"
   },
@@ -1091,7 +1091,7 @@
     "version": "1.4.0-dev93",
     "tag": "1.3.11-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code>\n<strong>WPC</strong>: <code>0.0.2-dev93</code>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev93</code><br>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
     "published_at": "2025-07-22T00:40:35+00:00",
     "type": "dev"
   },
@@ -1099,7 +1099,7 @@
     "version": "1.4.0-beta493",
     "tag": "1.3.11-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code>\n<strong>WPC</strong>: <code>0.0.2-beta493</code>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta493</code><br>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
     "published_at": "2025-07-18T20:12:57+00:00",
     "type": "beta"
   },
@@ -1107,7 +1107,7 @@
     "version": "1.4.0-beta502",
     "tag": "1.3.11-beta502",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code>\n<strong>WPC</strong>: <code>0.0.2-beta502</code>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta502</code><br>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
     "published_at": "2025-07-27T16:56:03+00:00",
     "type": "beta"
   },
@@ -1115,7 +1115,7 @@
     "version": "1.4.1-dev98",
     "tag": "1.3.12-dev98",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code>\n<strong>WPC</strong>: <code>0.0.3-dev98</code>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev98</code><br>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
     "published_at": "2025-07-30T12:57:34+00:00",
     "type": "dev"
   },
@@ -1123,7 +1123,7 @@
     "version": "1.4.1-dev97",
     "tag": "1.3.12-dev97",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code>\n<strong>WPC</strong>: <code>0.0.3-dev97</code>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev97</code><br>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
     "published_at": "2025-07-30T12:43:13+00:00",
     "type": "dev"
   },
@@ -1131,7 +1131,7 @@
     "version": "1.4.1-beta504",
     "tag": "1.3.12-beta504",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code>\n<strong>WPC</strong>: <code>0.0.3-beta504</code>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code><br>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code><br>\n<strong>WPC</strong>: <code>0.0.3-beta504</code><br>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
     "published_at": "2025-07-27T16:59:36+00:00",
     "type": "beta"
   }

--- a/docs/vector/sys11/beta.json
+++ b/docs/vector/sys11/beta.json
@@ -3,7 +3,7 @@
     "version": "0.3.0-beta-116",
     "tag": "0.3.0-beta-116",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.3.0-beta-116</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.3.0-beta-116</p>",
     "published_at": "2025-01-26T17:00:14+00:00",
     "type": "beta"
   },
@@ -11,7 +11,7 @@
     "version": "0.4.0-beta123",
     "tag": "0.4.0-beta123",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.0-beta123</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.0-beta123</p>",
     "published_at": "2025-01-28T22:23:22+00:00",
     "type": "beta"
   },
@@ -19,7 +19,7 @@
     "version": "0.4.0-beta126",
     "tag": "0.4.0-beta126",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.0-beta126</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.0-beta126</p>",
     "published_at": "2025-01-28T23:32:55+00:00",
     "type": "beta"
   },
@@ -27,7 +27,7 @@
     "version": "0.4.0-beta130",
     "tag": "0.4.0-beta130",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.0-beta130</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.0-beta130</p>",
     "published_at": "2025-02-01T23:36:46+00:00",
     "type": "beta"
   },
@@ -35,7 +35,7 @@
     "version": "0.4.1-beta135",
     "tag": "0.4.1-beta135",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.1-beta135</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.1-beta135</p>",
     "published_at": "2025-02-01T23:48:13+00:00",
     "type": "beta"
   },
@@ -43,7 +43,7 @@
     "version": "0.4.2-beta139",
     "tag": "0.4.2-beta139",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.2-beta139</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.2-beta139</p>",
     "published_at": "2025-02-02T03:06:44+00:00",
     "type": "beta"
   },
@@ -51,7 +51,7 @@
     "version": "0.4.3-beta145",
     "tag": "0.4.3-beta145",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.3-beta145</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.3-beta145</p>",
     "published_at": "2025-02-02T16:46:59+00:00",
     "type": "beta"
   },
@@ -59,7 +59,7 @@
     "version": "0.4.4-beta149",
     "tag": "0.4.4-beta149",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.4-beta149</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.4-beta149</p>",
     "published_at": "2025-02-04T01:02:49+00:00",
     "type": "beta"
   },
@@ -67,7 +67,7 @@
     "version": "0.4.4-beta160",
     "tag": "0.4.4-beta160",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 0.4.4-beta160</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 0.4.4-beta160</p>",
     "published_at": "2025-02-06T22:57:10+00:00",
     "type": "beta"
   },
@@ -75,7 +75,7 @@
     "version": "1.0.0-beta203",
     "tag": "1.0.0-beta203",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.0.0-beta203</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.0.0-beta203</p>",
     "published_at": "2025-02-23T19:57:39+00:00",
     "type": "beta"
   },
@@ -83,7 +83,7 @@
     "version": "1.0.0-beta211",
     "tag": "1.0.0-beta211",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.0.0-beta211</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.0.0-beta211</p>",
     "published_at": "2025-02-26T01:31:32+00:00",
     "type": "beta"
   },
@@ -91,7 +91,7 @@
     "version": "1.0.0-beta225",
     "tag": "1.0.0-beta225",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.0.0-beta225</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.0.0-beta225</p>",
     "published_at": "2025-03-01T01:37:48+00:00",
     "type": "beta"
   },
@@ -99,7 +99,7 @@
     "version": "1.1.0-beta227",
     "tag": "1.1.0-beta227",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.1.0-beta227</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.1.0-beta227</p>",
     "published_at": "2025-03-01T01:39:02+00:00",
     "type": "beta"
   },
@@ -107,7 +107,7 @@
     "version": "1.2.0-beta235",
     "tag": "1.2.0-beta235",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta235</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta235</p>",
     "published_at": "2025-03-02T02:11:41+00:00",
     "type": "beta"
   },
@@ -115,7 +115,7 @@
     "version": "1.2.0-beta246",
     "tag": "1.2.0-beta246",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta246</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta246</p>",
     "published_at": "2025-03-02T15:06:22+00:00",
     "type": "beta"
   },
@@ -123,7 +123,7 @@
     "version": "1.2.0-beta247",
     "tag": "1.2.0-beta247",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta247</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta247</p>",
     "published_at": "2025-03-02T15:06:45+00:00",
     "type": "beta"
   },
@@ -131,7 +131,7 @@
     "version": "1.2.0-beta251",
     "tag": "1.2.0-beta251",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta251</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta251</p>",
     "published_at": "2025-03-02T17:51:26+00:00",
     "type": "beta"
   },
@@ -139,7 +139,7 @@
     "version": "1.2.0-beta254",
     "tag": "1.2.0-beta254",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.2.0-beta254</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.2.0-beta254</p>",
     "published_at": "2025-03-02T18:14:40+00:00",
     "type": "beta"
   },
@@ -147,7 +147,7 @@
     "version": "1.3.0-beta258",
     "tag": "1.3.0-beta258",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.0-beta258</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.0-beta258</p>",
     "published_at": "2025-03-02T18:46:18+00:00",
     "type": "beta"
   },
@@ -155,7 +155,7 @@
     "version": "1.3.0-beta262",
     "tag": "1.3.0-beta262",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.0-beta262</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.0-beta262</p>",
     "published_at": "2025-03-03T02:26:06+00:00",
     "type": "beta"
   },
@@ -163,7 +163,7 @@
     "version": "1.3.1-beta310",
     "tag": "1.3.1-beta310",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.1-beta310</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.1-beta310</p>",
     "published_at": "2025-03-08T01:30:28+00:00",
     "type": "beta"
   },
@@ -171,7 +171,7 @@
     "version": "1.3.2-beta320",
     "tag": "1.3.2-beta320",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta320</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta320</p>",
     "published_at": "2025-03-09T17:26:29+00:00",
     "type": "beta"
   },
@@ -179,7 +179,7 @@
     "version": "1.3.2-beta319",
     "tag": "1.3.2-beta319",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta319</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta319</p>",
     "published_at": "2025-03-09T17:26:07+00:00",
     "type": "beta"
   },
@@ -187,7 +187,7 @@
     "version": "1.3.2-beta324",
     "tag": "1.3.2-beta324",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta324</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta324</p>",
     "published_at": "2025-03-09T17:33:04+00:00",
     "type": "beta"
   },
@@ -195,7 +195,7 @@
     "version": "1.3.2-beta327",
     "tag": "1.3.2-beta327",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.2-beta327</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.2-beta327</p>",
     "published_at": "2025-03-09T21:49:26+00:00",
     "type": "beta"
   },
@@ -203,7 +203,7 @@
     "version": "1.3.3-beta330",
     "tag": "1.3.3-beta330",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.3-beta330</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.3-beta330</p>",
     "published_at": "2025-03-09T21:51:50+00:00",
     "type": "beta"
   },
@@ -211,7 +211,7 @@
     "version": "1.3.4-beta338",
     "tag": "1.3.4-beta338",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.4-beta338</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.4-beta338</p>",
     "published_at": "2025-03-12T02:36:53+00:00",
     "type": "beta"
   },
@@ -219,7 +219,7 @@
     "version": "1.3.4-beta358",
     "tag": "1.3.4-beta358",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.4-beta358</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.4-beta358</p>",
     "published_at": "2025-03-22T20:32:57+00:00",
     "type": "beta"
   },
@@ -227,7 +227,7 @@
     "version": "1.3.5-beta361",
     "tag": "1.3.5-beta361",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.5-beta361</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.5-beta361</p>",
     "published_at": "2025-03-23T20:44:01+00:00",
     "type": "beta"
   },
@@ -235,7 +235,7 @@
     "version": "1.3.5-beta363",
     "tag": "1.3.5-beta363",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.5-beta363</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.5-beta363</p>",
     "published_at": "2025-03-23T20:51:10+00:00",
     "type": "beta"
   },
@@ -243,7 +243,7 @@
     "version": "1.3.5-beta372",
     "tag": "1.3.5-beta372",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.5-beta372</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.5-beta372</p>",
     "published_at": "2025-03-27T23:54:32+00:00",
     "type": "beta"
   },
@@ -251,7 +251,7 @@
     "version": "1.3.6-beta376",
     "tag": "1.3.6-beta376",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.6-beta376</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.6-beta376</p>",
     "published_at": "2025-03-28T00:12:27+00:00",
     "type": "beta"
   },
@@ -259,7 +259,7 @@
     "version": "1.3.6-beta378",
     "tag": "1.3.6-beta378",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.6-beta378</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.6-beta378</p>",
     "published_at": "2025-03-28T00:13:00+00:00",
     "type": "beta"
   },
@@ -267,7 +267,7 @@
     "version": "1.3.7-beta381",
     "tag": "1.3.7-beta381",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.7-beta381</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.7-beta381</p>",
     "published_at": "2025-04-01T00:42:48+00:00",
     "type": "beta"
   },
@@ -275,7 +275,7 @@
     "version": "1.3.8-beta386",
     "tag": "1.3.8-beta386",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta386</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta386</p>",
     "published_at": "2025-04-11T18:47:45+00:00",
     "type": "beta"
   },
@@ -283,7 +283,7 @@
     "version": "1.3.8-beta394",
     "tag": "1.3.8-beta394",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta394</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta394</p>",
     "published_at": "2025-05-06T00:11:44+00:00",
     "type": "beta"
   },
@@ -291,7 +291,7 @@
     "version": "1.3.8-beta396",
     "tag": "1.3.8-beta396",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta396</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta396</p>",
     "published_at": "2025-05-20T00:53:56+00:00",
     "type": "beta"
   },
@@ -299,7 +299,7 @@
     "version": "1.3.8-beta399",
     "tag": "1.3.8-beta399",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.8-beta399</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.8-beta399</p>",
     "published_at": "2025-05-20T02:38:42+00:00",
     "type": "beta"
   },
@@ -307,7 +307,7 @@
     "version": "1.3.9-beta404",
     "tag": "1.3.9-beta404",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.9-beta404</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.9-beta404</p>",
     "published_at": "2025-05-21T02:04:22+00:00",
     "type": "beta"
   },
@@ -315,7 +315,7 @@
     "version": "1.3.9-beta408",
     "tag": "1.3.9-beta408",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.9-beta408</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.9-beta408</p>",
     "published_at": "2025-05-26T22:24:34+00:00",
     "type": "beta"
   },
@@ -323,7 +323,7 @@
     "version": "1.3.10-beta419",
     "tag": "1.3.10-beta419",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "notes": "<p>PR: \nBranch: \nVersion: 1.3.10-beta419</p>",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.10-beta419</p>",
     "published_at": "2025-06-19T00:22:15+00:00",
     "type": "beta"
   },
@@ -331,7 +331,7 @@
     "version": "1.4.0-beta479",
     "tag": "1.3.11-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code>\n<strong>WPC</strong>: <code>0.0.1-beta479</code>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta479</code><br>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
     "published_at": "2025-07-05T15:07:23+00:00",
     "type": "beta"
   },
@@ -339,7 +339,7 @@
     "version": "1.4.0-beta481",
     "tag": "1.3.11-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code>\n<strong>WPC</strong>: <code>0.0.1-beta481</code>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta481</code><br>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
     "published_at": "2025-07-05T16:17:59+00:00",
     "type": "beta"
   },
@@ -347,7 +347,7 @@
     "version": "1.4.0-beta486",
     "tag": "1.3.11-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code>\n<strong>WPC</strong>: <code>0.0.1-beta486</code>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta486</code><br>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
     "published_at": "2025-07-08T22:43:34+00:00",
     "type": "beta"
   },
@@ -355,7 +355,7 @@
     "version": "1.4.0-beta493",
     "tag": "1.3.11-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code>\n<strong>WPC</strong>: <code>0.0.2-beta493</code>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta493</code><br>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
     "published_at": "2025-07-18T20:12:57+00:00",
     "type": "beta"
   },
@@ -363,7 +363,7 @@
     "version": "1.4.0-beta502",
     "tag": "1.3.11-beta502",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code>\n<strong>WPC</strong>: <code>0.0.2-beta502</code>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta502</code><br>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
     "published_at": "2025-07-27T16:56:03+00:00",
     "type": "beta"
   },
@@ -371,7 +371,7 @@
     "version": "1.4.1-beta504",
     "tag": "1.3.12-beta504",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code>\n<strong>WPC</strong>: <code>0.0.3-beta504</code>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code><br>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code><br>\n<strong>WPC</strong>: <code>0.0.3-beta504</code><br>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
     "published_at": "2025-07-27T16:59:36+00:00",
     "type": "beta"
   }

--- a/docs/vector/sys11/dev.json
+++ b/docs/vector/sys11/dev.json
@@ -3,7 +3,7 @@
     "version": "0.4.0-dev24",
     "tag": "0.4.0-dev24",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/24\nBranch: pre-commit-changes\nVersion: 0.4.0-dev24</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/24<br>\nBranch: pre-commit-changes<br>\nVersion: 0.4.0-dev24</p>",
     "published_at": "2025-01-19T22:45:30+00:00",
     "type": "dev"
   },
@@ -11,7 +11,7 @@
     "version": "0.4.0-dev22",
     "tag": "0.4.0-dev22",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/22\nBranch: Serial_Flash_Test\nVersion: 0.4.0-dev22</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/22<br>\nBranch: Serial_Flash_Test<br>\nVersion: 0.4.0-dev22</p>",
     "published_at": "2025-01-19T03:00:13+00:00",
     "type": "dev"
   },
@@ -19,7 +19,7 @@
     "version": "0.4.0-dev25",
     "tag": "0.4.0-dev25",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/25\nBranch: network-discovery\nVersion: 0.4.0-dev25</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/25<br>\nBranch: network-discovery<br>\nVersion: 0.4.0-dev25</p>",
     "published_at": "2025-01-26T19:37:25+00:00",
     "type": "dev"
   },
@@ -27,7 +27,7 @@
     "version": "0.4.1-dev28",
     "tag": "0.4.1-dev28",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/28\nBranch: cancel-button-fix\nVersion: 0.4.1-dev28</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/28<br>\nBranch: cancel-button-fix<br>\nVersion: 0.4.1-dev28</p>",
     "published_at": "2025-02-01T23:38:40+00:00",
     "type": "dev"
   },
@@ -35,7 +35,7 @@
     "version": "0.4.0-dev29",
     "tag": "0.4.0-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.0-dev29</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29<br>\nBranch: scores<br>\nVersion: 0.4.0-dev29</p>",
     "published_at": "2025-02-01T23:42:13+00:00",
     "type": "dev"
   },
@@ -43,7 +43,7 @@
     "version": "0.4.2-dev30",
     "tag": "0.4.2-dev30",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/30\nBranch: no-discovery-in-ap-mode\nVersion: 0.4.2-dev30</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/30<br>\nBranch: no-discovery-in-ap-mode<br>\nVersion: 0.4.2-dev30</p>",
     "published_at": "2025-02-02T02:53:34+00:00",
     "type": "dev"
   },
@@ -51,7 +51,7 @@
     "version": "0.4.1-dev29",
     "tag": "0.4.1-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.1-dev29</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29<br>\nBranch: scores<br>\nVersion: 0.4.1-dev29</p>",
     "published_at": "2025-02-01T23:49:39+00:00",
     "type": "dev"
   },
@@ -59,7 +59,7 @@
     "version": "0.4.3-dev31",
     "tag": "0.4.3-dev31",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/31\nBranch: authenticate-for-logs\nVersion: 0.4.3-dev31</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/31<br>\nBranch: authenticate-for-logs<br>\nVersion: 0.4.3-dev31</p>",
     "published_at": "2025-02-02T16:34:19+00:00",
     "type": "dev"
   },
@@ -67,7 +67,7 @@
     "version": "0.4.3-dev29",
     "tag": "0.4.3-dev29",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29\nBranch: scores\nVersion: 0.4.3-dev29</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/29<br>\nBranch: scores<br>\nVersion: 0.4.3-dev29</p>",
     "published_at": "2025-02-02T03:21:43+00:00",
     "type": "dev"
   },
@@ -75,7 +75,7 @@
     "version": "0.4.4-dev32",
     "tag": "0.4.4-dev32",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/32\nBranch: main_0_4_0_testing\nVersion: 0.4.4-dev32</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/32<br>\nBranch: main_0_4_0_testing<br>\nVersion: 0.4.4-dev32</p>",
     "published_at": "2025-02-03T21:50:24+00:00",
     "type": "dev"
   },
@@ -83,7 +83,7 @@
     "version": "1.0.0-dev35",
     "tag": "1.0.0-dev35",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/35\nBranch: update-logic-fix\nVersion: 1.0.0-dev35</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/35<br>\nBranch: update-logic-fix<br>\nVersion: 1.0.0-dev35</p>",
     "published_at": "2025-02-06T04:13:37+00:00",
     "type": "dev"
   },
@@ -91,7 +91,7 @@
     "version": "0.4.5-dev33",
     "tag": "0.4.5-dev33",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/33\nBranch: KISS-scores\nVersion: 0.4.5-dev33</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/33<br>\nBranch: KISS-scores<br>\nVersion: 0.4.5-dev33</p>",
     "published_at": "2025-02-05T04:13:36+00:00",
     "type": "dev"
   },
@@ -99,7 +99,7 @@
     "version": "0.4.4-dev34",
     "tag": "0.4.4-dev34",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/34\nBranch: Factory-Reset\nVersion: 0.4.4-dev34</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/34<br>\nBranch: Factory-Reset<br>\nVersion: 0.4.4-dev34</p>",
     "published_at": "2025-02-05T19:53:48+00:00",
     "type": "dev"
   },
@@ -107,7 +107,7 @@
     "version": "1.0.0-dev43",
     "tag": "1.0.0-dev43",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/43\nBranch: memory-efficiency\nVersion: 1.0.0-dev43</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/43<br>\nBranch: memory-efficiency<br>\nVersion: 1.0.0-dev43</p>",
     "published_at": "2025-02-25T02:49:28+00:00",
     "type": "dev"
   },
@@ -115,7 +115,7 @@
     "version": "1.1.0-dev45",
     "tag": "1.1.0-dev45",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/45\nBranch: wifi-reconnect\nVersion: 1.1.0-dev45</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/45<br>\nBranch: wifi-reconnect<br>\nVersion: 1.1.0-dev45</p>",
     "published_at": "2025-02-26T03:22:37+00:00",
     "type": "dev"
   },
@@ -123,7 +123,7 @@
     "version": "1.0.0-dev47",
     "tag": "1.0.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.0.0-dev47</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47<br>\nBranch: live-scores-webui<br>\nVersion: 1.0.0-dev47</p>",
     "published_at": "2025-02-26T23:04:19+00:00",
     "type": "dev"
   },
@@ -131,7 +131,7 @@
     "version": "1.0.0-dev46",
     "tag": "1.0.0-dev46",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/46\nBranch: logging\nVersion: 1.0.0-dev46</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/46<br>\nBranch: logging<br>\nVersion: 1.0.0-dev46</p>",
     "published_at": "2025-02-26T03:36:54+00:00",
     "type": "dev"
   },
@@ -139,7 +139,7 @@
     "version": "1.0.0-dev44",
     "tag": "1.0.0-dev44",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/44\nBranch: memory-efficiency\nVersion: 1.0.0-dev44</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/44<br>\nBranch: memory-efficiency<br>\nVersion: 1.0.0-dev44</p>",
     "published_at": "2025-02-26T01:38:58+00:00",
     "type": "dev"
   },
@@ -147,7 +147,7 @@
     "version": "1.2.0-dev47",
     "tag": "1.2.0-dev47",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47\nBranch: live-scores-webui\nVersion: 1.2.0-dev47</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/47<br>\nBranch: live-scores-webui<br>\nVersion: 1.2.0-dev47</p>",
     "published_at": "2025-03-01T01:45:10+00:00",
     "type": "dev"
   },
@@ -155,7 +155,7 @@
     "version": "1.1.0-dev49",
     "tag": "1.1.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.1.0-dev49</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49<br>\nBranch: discovery-recovery<br>\nVersion: 1.1.0-dev49</p>",
     "published_at": "2025-03-02T01:58:59+00:00",
     "type": "dev"
   },
@@ -163,7 +163,7 @@
     "version": "1.1.0-dev48",
     "tag": "1.1.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.1.0-dev48</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48<br>\nBranch: fix-overlapping-routes<br>\nVersion: 1.1.0-dev48</p>",
     "published_at": "2025-03-02T01:31:46+00:00",
     "type": "dev"
   },
@@ -171,7 +171,7 @@
     "version": "1.2.0-dev53",
     "tag": "1.2.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.2.0-dev53</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53<br>\nBranch: disaplymessage_robusto<br>\nVersion: 1.2.0-dev53</p>",
     "published_at": "2025-03-02T13:11:53+00:00",
     "type": "dev"
   },
@@ -179,7 +179,7 @@
     "version": "1.2.0-dev52",
     "tag": "1.2.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.2.0-dev52</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52<br>\nBranch: js-linter<br>\nVersion: 1.2.0-dev52</p>",
     "published_at": "2025-03-02T04:43:50+00:00",
     "type": "dev"
   },
@@ -187,7 +187,7 @@
     "version": "1.2.0-dev51",
     "tag": "1.2.0-dev51",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/51\nBranch: show-ip-toggle\nVersion: 1.2.0-dev51</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/51<br>\nBranch: show-ip-toggle<br>\nVersion: 1.2.0-dev51</p>",
     "published_at": "2025-03-02T02:47:20+00:00",
     "type": "dev"
   },
@@ -195,7 +195,7 @@
     "version": "1.2.0-dev50",
     "tag": "1.2.0-dev50",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/50\nBranch: web-ui-claim-toggle\nVersion: 1.2.0-dev50</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/50<br>\nBranch: web-ui-claim-toggle<br>\nVersion: 1.2.0-dev50</p>",
     "published_at": "2025-03-02T02:15:04+00:00",
     "type": "dev"
   },
@@ -203,7 +203,7 @@
     "version": "1.2.0-dev49",
     "tag": "1.2.0-dev49",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49\nBranch: discovery-recovery\nVersion: 1.2.0-dev49</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/49<br>\nBranch: discovery-recovery<br>\nVersion: 1.2.0-dev49</p>",
     "published_at": "2025-03-02T02:20:30+00:00",
     "type": "dev"
   },
@@ -211,7 +211,7 @@
     "version": "1.2.0-dev48",
     "tag": "1.2.0-dev48",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48\nBranch: fix-overlapping-routes\nVersion: 1.2.0-dev48</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/48<br>\nBranch: fix-overlapping-routes<br>\nVersion: 1.2.0-dev48</p>",
     "published_at": "2025-03-02T02:20:00+00:00",
     "type": "dev"
   },
@@ -219,7 +219,7 @@
     "version": "1.3.0-dev52",
     "tag": "1.3.0-dev52",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52\nBranch: js-linter\nVersion: 1.3.0-dev52</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/52<br>\nBranch: js-linter<br>\nVersion: 1.3.0-dev52</p>",
     "published_at": "2025-03-02T18:26:23+00:00",
     "type": "dev"
   },
@@ -227,7 +227,7 @@
     "version": "1.3.0-dev55",
     "tag": "1.3.0-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.0-dev55</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55<br>\nBranch: Testing-and-bug-resolution<br>\nVersion: 1.3.0-dev55</p>",
     "published_at": "2025-03-03T00:14:20+00:00",
     "type": "dev"
   },
@@ -235,7 +235,7 @@
     "version": "1.3.0-dev54",
     "tag": "1.3.0-dev54",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/54\nBranch: route-quick-fix\nVersion: 1.3.0-dev54</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/54<br>\nBranch: route-quick-fix<br>\nVersion: 1.3.0-dev54</p>",
     "published_at": "2025-03-02T23:21:53+00:00",
     "type": "dev"
   },
@@ -243,7 +243,7 @@
     "version": "1.3.0-dev53",
     "tag": "1.3.0-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.0-dev53</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53<br>\nBranch: disaplymessage_robusto<br>\nVersion: 1.3.0-dev53</p>",
     "published_at": "2025-03-02T19:21:48+00:00",
     "type": "dev"
   },
@@ -251,7 +251,7 @@
     "version": "1.3.1-dev58",
     "tag": "1.3.1-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.1-dev58</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58<br>\nBranch: KISS-scores-reload<br>\nVersion: 1.3.1-dev58</p>",
     "published_at": "2025-03-06T04:10:33+00:00",
     "type": "dev"
   },
@@ -259,7 +259,7 @@
     "version": "1.3.1-dev55",
     "tag": "1.3.1-dev55",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55\nBranch: Testing-and-bug-resolution\nVersion: 1.3.1-dev55</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/55<br>\nBranch: Testing-and-bug-resolution<br>\nVersion: 1.3.1-dev55</p>",
     "published_at": "2025-03-06T21:14:36+00:00",
     "type": "dev"
   },
@@ -267,7 +267,7 @@
     "version": "1.3.0-dev59",
     "tag": "1.3.0-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.0-dev59</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59<br>\nBranch: sort-tournament-by-game<br>\nVersion: 1.3.0-dev59</p>",
     "published_at": "2025-03-08T01:01:04+00:00",
     "type": "dev"
   },
@@ -275,7 +275,7 @@
     "version": "1.3.0-dev57",
     "tag": "1.3.0-dev57",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/57\nBranch: combine-api-routes\nVersion: 1.3.0-dev57</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/57<br>\nBranch: combine-api-routes<br>\nVersion: 1.3.0-dev57</p>",
     "published_at": "2025-03-04T03:52:39+00:00",
     "type": "dev"
   },
@@ -283,7 +283,7 @@
     "version": "1.3.0-dev56",
     "tag": "1.3.0-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.0-dev56</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56<br>\nBranch: automated-testing<br>\nVersion: 1.3.0-dev56</p>",
     "published_at": "2025-03-03T02:31:26+00:00",
     "type": "dev"
   },
@@ -291,7 +291,7 @@
     "version": "1.3.2-dev61",
     "tag": "1.3.2-dev61",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/61\nBranch: light-mode-style-fixes\nVersion: 1.3.2-dev61</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/61<br>\nBranch: light-mode-style-fixes<br>\nVersion: 1.3.2-dev61</p>",
     "published_at": "2025-03-09T17:10:25+00:00",
     "type": "dev"
   },
@@ -299,7 +299,7 @@
     "version": "1.3.2-dev60",
     "tag": "1.3.2-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.2-dev60</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60<br>\nBranch: claim-in-tournament<br>\nVersion: 1.3.2-dev60</p>",
     "published_at": "2025-03-09T01:49:28+00:00",
     "type": "dev"
   },
@@ -307,7 +307,7 @@
     "version": "1.3.1-dev60",
     "tag": "1.3.1-dev60",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60\nBranch: claim-in-tournament\nVersion: 1.3.1-dev60</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/60<br>\nBranch: claim-in-tournament<br>\nVersion: 1.3.1-dev60</p>",
     "published_at": "2025-03-08T04:07:36+00:00",
     "type": "dev"
   },
@@ -315,7 +315,7 @@
     "version": "1.3.1-dev59",
     "tag": "1.3.1-dev59",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59\nBranch: sort-tournament-by-game\nVersion: 1.3.1-dev59</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/59<br>\nBranch: sort-tournament-by-game<br>\nVersion: 1.3.1-dev59</p>",
     "published_at": "2025-03-09T17:25:13+00:00",
     "type": "dev"
   },
@@ -323,7 +323,7 @@
     "version": "1.3.1-dev56",
     "tag": "1.3.1-dev56",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56\nBranch: automated-testing\nVersion: 1.3.1-dev56</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/56<br>\nBranch: automated-testing<br>\nVersion: 1.3.1-dev56</p>",
     "published_at": "2025-03-09T17:13:13+00:00",
     "type": "dev"
   },
@@ -331,7 +331,7 @@
     "version": "1.3.2-dev58",
     "tag": "1.3.2-dev58",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58\nBranch: KISS-scores-reload\nVersion: 1.3.2-dev58</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/58<br>\nBranch: KISS-scores-reload<br>\nVersion: 1.3.2-dev58</p>",
     "published_at": "2025-03-09T17:26:50+00:00",
     "type": "dev"
   },
@@ -339,7 +339,7 @@
     "version": "1.3.2-dev53",
     "tag": "1.3.2-dev53",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53\nBranch: disaplymessage_robusto\nVersion: 1.3.2-dev53</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/53<br>\nBranch: disaplymessage_robusto<br>\nVersion: 1.3.2-dev53</p>",
     "published_at": "2025-03-09T17:29:06+00:00",
     "type": "dev"
   },
@@ -347,7 +347,7 @@
     "version": "1.3.2-dev62",
     "tag": "1.3.2-dev62",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/62\nBranch: short-initials\nVersion: 1.3.2-dev62</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/62<br>\nBranch: short-initials<br>\nVersion: 1.3.2-dev62</p>",
     "published_at": "2025-03-09T20:17:00+00:00",
     "type": "dev"
   },
@@ -355,7 +355,7 @@
     "version": "1.3.4-dev64",
     "tag": "1.3.4-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.4-dev64</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64<br>\nBranch: log-adjustments<br>\nVersion: 1.3.4-dev64</p>",
     "published_at": "2025-03-12T02:36:22+00:00",
     "type": "dev"
   },
@@ -363,7 +363,7 @@
     "version": "1.3.3-dev64",
     "tag": "1.3.3-dev64",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64\nBranch: log-adjustments\nVersion: 1.3.3-dev64</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/64<br>\nBranch: log-adjustments<br>\nVersion: 1.3.3-dev64</p>",
     "published_at": "2025-03-10T22:27:24+00:00",
     "type": "dev"
   },
@@ -371,7 +371,7 @@
     "version": "1.3.3-dev63",
     "tag": "1.3.3-dev63",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/63\nBranch: version-bump\nVersion: 1.3.3-dev63</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/63<br>\nBranch: version-bump<br>\nVersion: 1.3.3-dev63</p>",
     "published_at": "2025-03-09T21:51:53+00:00",
     "type": "dev"
   },
@@ -379,7 +379,7 @@
     "version": "1.3.4-dev68",
     "tag": "1.3.4-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.4-dev68</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68<br>\nBranch: live-scores-clear<br>\nVersion: 1.3.4-dev68</p>",
     "published_at": "2025-03-22T14:42:01+00:00",
     "type": "dev"
   },
@@ -387,7 +387,7 @@
     "version": "1.3.4-dev67",
     "tag": "1.3.4-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.4-dev67</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67<br>\nBranch: diner_fix<br>\nVersion: 1.3.4-dev67</p>",
     "published_at": "2025-03-21T01:50:43+00:00",
     "type": "dev"
   },
@@ -395,7 +395,7 @@
     "version": "1.3.4-dev66",
     "tag": "1.3.4-dev66",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/66\nBranch: improved-readme\nVersion: 1.3.4-dev66</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/66<br>\nBranch: improved-readme<br>\nVersion: 1.3.4-dev66</p>",
     "published_at": "2025-03-20T03:50:27+00:00",
     "type": "dev"
   },
@@ -403,7 +403,7 @@
     "version": "1.3.4-dev65",
     "tag": "1.3.4-dev65",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/65\nBranch: Zoom-Demo-TPF\nVersion: 1.3.4-dev65</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/65<br>\nBranch: Zoom-Demo-TPF<br>\nVersion: 1.3.4-dev65</p>",
     "published_at": "2025-03-14T20:48:15+00:00",
     "type": "dev"
   },
@@ -411,7 +411,7 @@
     "version": "1.3.5-dev70",
     "tag": "1.3.5-dev70",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/70\nBranch: version-bump\nVersion: 1.3.5-dev70</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/70<br>\nBranch: version-bump<br>\nVersion: 1.3.5-dev70</p>",
     "published_at": "2025-03-23T20:42:40+00:00",
     "type": "dev"
   },
@@ -419,7 +419,7 @@
     "version": "1.3.5-dev67",
     "tag": "1.3.5-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67\nBranch: diner_fix\nVersion: 1.3.5-dev67</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/67<br>\nBranch: diner_fix<br>\nVersion: 1.3.5-dev67</p>",
     "published_at": "2025-03-23T20:50:37+00:00",
     "type": "dev"
   },
@@ -427,7 +427,7 @@
     "version": "1.3.6-dev68",
     "tag": "1.3.6-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.6-dev68</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68<br>\nBranch: live-scores-clear<br>\nVersion: 1.3.6-dev68</p>",
     "published_at": "2025-03-27T19:29:06+00:00",
     "type": "dev"
   },
@@ -435,7 +435,7 @@
     "version": "1.3.5-dev68",
     "tag": "1.3.5-dev68",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68\nBranch: live-scores-clear\nVersion: 1.3.5-dev68</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/68<br>\nBranch: live-scores-clear<br>\nVersion: 1.3.5-dev68</p>",
     "published_at": "2025-03-27T00:43:16+00:00",
     "type": "dev"
   },
@@ -443,7 +443,7 @@
     "version": "1.3.5-dev72",
     "tag": "1.3.5-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.5-dev72</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72<br>\nBranch: readme-contributors<br>\nVersion: 1.3.5-dev72</p>",
     "published_at": "2025-03-28T00:09:24+00:00",
     "type": "dev"
   },
@@ -451,7 +451,7 @@
     "version": "1.3.7-dev73",
     "tag": "1.3.7-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.7-dev73</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73<br>\nBranch: Space-Station-Fix<br>\nVersion: 1.3.7-dev73</p>",
     "published_at": "2025-04-01T00:04:20+00:00",
     "type": "dev"
   },
@@ -459,7 +459,7 @@
     "version": "1.3.6-dev73",
     "tag": "1.3.6-dev73",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73\nBranch: Space-Station-Fix\nVersion: 1.3.6-dev73</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/73<br>\nBranch: Space-Station-Fix<br>\nVersion: 1.3.6-dev73</p>",
     "published_at": "2025-04-01T00:03:22+00:00",
     "type": "dev"
   },
@@ -467,7 +467,7 @@
     "version": "1.3.6-dev72",
     "tag": "1.3.6-dev72",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72\nBranch: readme-contributors\nVersion: 1.3.6-dev72</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/72<br>\nBranch: readme-contributors<br>\nVersion: 1.3.6-dev72</p>",
     "published_at": "2025-03-28T00:12:53+00:00",
     "type": "dev"
   },
@@ -475,7 +475,7 @@
     "version": "1.3.8-dev74",
     "tag": "1.3.8-dev74",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/74\nBranch: sys9-score-fix\nVersion: 1.3.8-dev74</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/74<br>\nBranch: sys9-score-fix<br>\nVersion: 1.3.8-dev74</p>",
     "published_at": "2025-04-11T17:27:47+00:00",
     "type": "dev"
   },
@@ -483,7 +483,7 @@
     "version": "1.3.8-dev78",
     "tag": "1.3.8-dev78",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/78\nBranch: wifi-retry-timeout\nVersion: 1.3.8-dev78</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/78<br>\nBranch: wifi-retry-timeout<br>\nVersion: 1.3.8-dev78</p>",
     "published_at": "2025-05-03T01:41:00+00:00",
     "type": "dev"
   },
@@ -491,7 +491,7 @@
     "version": "1.3.8-dev77",
     "tag": "1.3.8-dev77",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/77\nBranch: improved-discover\nVersion: 1.3.8-dev77</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/77<br>\nBranch: improved-discover<br>\nVersion: 1.3.8-dev77</p>",
     "published_at": "2025-04-17T21:38:55+00:00",
     "type": "dev"
   },
@@ -499,7 +499,7 @@
     "version": "1.3.8-dev76",
     "tag": "1.3.8-dev76",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/76\nBranch: Sorcerer-add\nVersion: 1.3.8-dev76</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/76<br>\nBranch: Sorcerer-add<br>\nVersion: 1.3.8-dev76</p>",
     "published_at": "2025-04-16T23:34:10+00:00",
     "type": "dev"
   },
@@ -507,7 +507,7 @@
     "version": "1.3.8-dev80",
     "tag": "1.3.8-dev80",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/80\nBranch: Whirlwind-Live-Scores\nVersion: 1.3.8-dev80</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/80<br>\nBranch: Whirlwind-Live-Scores<br>\nVersion: 1.3.8-dev80</p>",
     "published_at": "2025-05-20T01:46:42+00:00",
     "type": "dev"
   },
@@ -515,7 +515,7 @@
     "version": "1.3.9-dev81",
     "tag": "1.3.9-dev81",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/81\nBranch: version-bump\nVersion: 1.3.9-dev81</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/81<br>\nBranch: version-bump<br>\nVersion: 1.3.9-dev81</p>",
     "published_at": "2025-05-21T02:01:22+00:00",
     "type": "dev"
   },
@@ -523,7 +523,7 @@
     "version": "1.3.9-dev82",
     "tag": "1.3.9-dev82",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/82\nBranch: leader_reset\nVersion: 1.3.9-dev82</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/82<br>\nBranch: leader_reset<br>\nVersion: 1.3.9-dev82</p>",
     "published_at": "2025-05-26T21:08:30+00:00",
     "type": "dev"
   },
@@ -531,7 +531,7 @@
     "version": "1.3.10-dev84",
     "tag": "1.3.10-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.10-dev84</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84<br>\nBranch: Fire-in-play-data<br>\nVersion: 1.3.10-dev84</p>",
     "published_at": "2025-06-18T23:57:48+00:00",
     "type": "dev"
   },
@@ -539,7 +539,7 @@
     "version": "1.3.9-dev84",
     "tag": "1.3.9-dev84",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84\nBranch: Fire-in-play-data\nVersion: 1.3.9-dev84</p>",
+    "notes": "<p>PR: https://github.com/warped-pinball/vector/pull/84<br>\nBranch: Fire-in-play-data<br>\nVersion: 1.3.9-dev84</p>",
     "published_at": "2025-06-18T23:56:13+00:00",
     "type": "dev"
   },
@@ -547,7 +547,7 @@
     "version": "1.4.0-dev83",
     "tag": "1.3.11-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code>\n<strong>WPC</strong>: <code>0.0.1-dev83</code>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev83</code><br>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
     "published_at": "2025-06-24T01:11:06+00:00",
     "type": "dev"
   },
@@ -555,7 +555,7 @@
     "version": "1.3.10-dev83",
     "tag": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "notes": "<p>Version: 1.3.10-dev83\nTrigger: pull_request</p>",
+    "notes": "<p>Version: 1.3.10-dev83<br>\nTrigger: pull_request</p>",
     "published_at": "2025-06-19T02:25:50+00:00",
     "type": "dev"
   },
@@ -563,7 +563,7 @@
     "version": "1.4.0-dev89",
     "tag": "1.3.11-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code>\n<strong>WPC</strong>: <code>0.0.1-dev89</code>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev89</code><br>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
     "published_at": "2025-07-05T15:30:41+00:00",
     "type": "dev"
   },
@@ -571,7 +571,7 @@
     "version": "1.4.0-dev91",
     "tag": "1.3.11-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code>\n<strong>WPC</strong>: <code>0.0.1-dev91</code>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev91</code><br>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
     "published_at": "2025-07-08T19:03:49+00:00",
     "type": "dev"
   },
@@ -579,7 +579,7 @@
     "version": "1.4.0-dev90",
     "tag": "1.3.11-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code>\n<strong>WPC</strong>: <code>0.0.1-dev90</code>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev90</code><br>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
     "published_at": "2025-07-08T18:50:19+00:00",
     "type": "dev"
   },
@@ -587,7 +587,7 @@
     "version": "1.4.0-dev92",
     "tag": "1.3.11-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code>\n<strong>WPC</strong>: <code>0.0.2-dev92</code>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev92</code><br>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
     "published_at": "2025-07-12T22:23:49+00:00",
     "type": "dev"
   },
@@ -595,7 +595,7 @@
     "version": "1.4.1-dev93",
     "tag": "1.3.12-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code>\n<strong>WPC</strong>: <code>0.0.3-dev93</code>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev93</code><br>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
     "published_at": "2025-07-22T01:56:25+00:00",
     "type": "dev"
   },
@@ -603,7 +603,7 @@
     "version": "1.4.0-dev96",
     "tag": "1.3.11-dev96",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code>\n<strong>WPC</strong>: <code>0.0.2-dev96</code>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev96</code><br>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
     "published_at": "2025-07-25T03:12:55+00:00",
     "type": "dev"
   },
@@ -611,7 +611,7 @@
     "version": "1.4.0-dev95",
     "tag": "1.3.11-dev95",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code>\n<strong>WPC</strong>: <code>0.0.2-dev95</code>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev95</code><br>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
     "published_at": "2025-07-22T13:36:02+00:00",
     "type": "dev"
   },
@@ -619,7 +619,7 @@
     "version": "1.4.0-dev94",
     "tag": "1.3.11-dev94",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code>\n<strong>WPC</strong>: <code>0.0.2-dev94</code>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev94</code><br>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
     "published_at": "2025-07-22T13:20:11+00:00",
     "type": "dev"
   },
@@ -627,7 +627,7 @@
     "version": "1.4.0-dev93",
     "tag": "1.3.11-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code>\n<strong>WPC</strong>: <code>0.0.2-dev93</code>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev93</code><br>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
     "published_at": "2025-07-22T00:40:35+00:00",
     "type": "dev"
   },
@@ -635,7 +635,7 @@
     "version": "1.4.1-dev98",
     "tag": "1.3.12-dev98",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code>\n<strong>WPC</strong>: <code>0.0.3-dev98</code>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev98</code><br>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
     "published_at": "2025-07-30T12:57:34+00:00",
     "type": "dev"
   },
@@ -643,7 +643,7 @@
     "version": "1.4.1-dev97",
     "tag": "1.3.12-dev97",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code>\n<strong>WPC</strong>: <code>0.0.3-dev97</code>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev97</code><br>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
     "published_at": "2025-07-30T12:43:13+00:00",
     "type": "dev"
   }

--- a/docs/vector/wpc/all.json
+++ b/docs/vector/wpc/all.json
@@ -3,7 +3,7 @@
     "version": "0.0.1-dev83",
     "tag": "1.3.11-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code>\n<strong>WPC</strong>: <code>0.0.1-dev83</code>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev83</code><br>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
     "published_at": "2025-06-24T01:11:06+00:00",
     "type": "dev"
   },
@@ -11,7 +11,7 @@
     "version": "1.3.10-dev83",
     "tag": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "notes": "<p>Version: 1.3.10-dev83\nTrigger: pull_request</p>",
+    "notes": "<p>Version: 1.3.10-dev83<br>\nTrigger: pull_request</p>",
     "published_at": "2025-06-19T02:25:50+00:00",
     "type": "dev"
   },
@@ -19,7 +19,7 @@
     "version": "0.0.1-dev89",
     "tag": "1.3.11-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code>\n<strong>WPC</strong>: <code>0.0.1-dev89</code>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev89</code><br>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
     "published_at": "2025-07-05T15:30:41+00:00",
     "type": "dev"
   },
@@ -27,7 +27,7 @@
     "version": "0.0.1-beta479",
     "tag": "1.3.11-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code>\n<strong>WPC</strong>: <code>0.0.1-beta479</code>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta479</code><br>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
     "published_at": "2025-07-05T15:07:23+00:00",
     "type": "beta"
   },
@@ -35,7 +35,7 @@
     "version": "0.0.1-dev91",
     "tag": "1.3.11-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code>\n<strong>WPC</strong>: <code>0.0.1-dev91</code>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev91</code><br>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
     "published_at": "2025-07-08T19:03:49+00:00",
     "type": "dev"
   },
@@ -43,7 +43,7 @@
     "version": "0.0.1-dev90",
     "tag": "1.3.11-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code>\n<strong>WPC</strong>: <code>0.0.1-dev90</code>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev90</code><br>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
     "published_at": "2025-07-08T18:50:19+00:00",
     "type": "dev"
   },
@@ -51,7 +51,7 @@
     "version": "0.0.1-beta481",
     "tag": "1.3.11-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code>\n<strong>WPC</strong>: <code>0.0.1-beta481</code>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta481</code><br>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
     "published_at": "2025-07-05T16:17:59+00:00",
     "type": "beta"
   },
@@ -59,7 +59,7 @@
     "version": "0.0.2-dev92",
     "tag": "1.3.11-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code>\n<strong>WPC</strong>: <code>0.0.2-dev92</code>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev92</code><br>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
     "published_at": "2025-07-12T22:23:49+00:00",
     "type": "dev"
   },
@@ -67,7 +67,7 @@
     "version": "0.0.1-beta486",
     "tag": "1.3.11-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code>\n<strong>WPC</strong>: <code>0.0.1-beta486</code>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta486</code><br>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
     "published_at": "2025-07-08T22:43:34+00:00",
     "type": "beta"
   },
@@ -75,7 +75,7 @@
     "version": "0.0.3-dev93",
     "tag": "1.3.12-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code>\n<strong>WPC</strong>: <code>0.0.3-dev93</code>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev93</code><br>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
     "published_at": "2025-07-22T01:56:25+00:00",
     "type": "dev"
   },
@@ -83,7 +83,7 @@
     "version": "0.0.2-dev96",
     "tag": "1.3.11-dev96",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code>\n<strong>WPC</strong>: <code>0.0.2-dev96</code>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev96</code><br>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
     "published_at": "2025-07-25T03:12:55+00:00",
     "type": "dev"
   },
@@ -91,7 +91,7 @@
     "version": "0.0.2-dev95",
     "tag": "1.3.11-dev95",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code>\n<strong>WPC</strong>: <code>0.0.2-dev95</code>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev95</code><br>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
     "published_at": "2025-07-22T13:36:02+00:00",
     "type": "dev"
   },
@@ -99,7 +99,7 @@
     "version": "0.0.2-dev94",
     "tag": "1.3.11-dev94",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code>\n<strong>WPC</strong>: <code>0.0.2-dev94</code>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev94</code><br>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
     "published_at": "2025-07-22T13:20:11+00:00",
     "type": "dev"
   },
@@ -107,7 +107,7 @@
     "version": "0.0.2-dev93",
     "tag": "1.3.11-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code>\n<strong>WPC</strong>: <code>0.0.2-dev93</code>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev93</code><br>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
     "published_at": "2025-07-22T00:40:35+00:00",
     "type": "dev"
   },
@@ -115,7 +115,7 @@
     "version": "0.0.2-beta493",
     "tag": "1.3.11-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code>\n<strong>WPC</strong>: <code>0.0.2-beta493</code>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta493</code><br>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
     "published_at": "2025-07-18T20:12:57+00:00",
     "type": "beta"
   },
@@ -123,7 +123,7 @@
     "version": "0.0.2-beta502",
     "tag": "1.3.11-beta502",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code>\n<strong>WPC</strong>: <code>0.0.2-beta502</code>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta502</code><br>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
     "published_at": "2025-07-27T16:56:03+00:00",
     "type": "beta"
   },
@@ -131,7 +131,7 @@
     "version": "0.0.3-dev98",
     "tag": "1.3.12-dev98",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code>\n<strong>WPC</strong>: <code>0.0.3-dev98</code>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev98</code><br>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
     "published_at": "2025-07-30T12:57:34+00:00",
     "type": "dev"
   },
@@ -139,7 +139,7 @@
     "version": "0.0.3-dev97",
     "tag": "1.3.12-dev97",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code>\n<strong>WPC</strong>: <code>0.0.3-dev97</code>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev97</code><br>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
     "published_at": "2025-07-30T12:43:13+00:00",
     "type": "dev"
   },
@@ -147,7 +147,7 @@
     "version": "0.0.3-beta504",
     "tag": "1.3.12-beta504",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code>\n<strong>WPC</strong>: <code>0.0.3-beta504</code>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code><br>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code><br>\n<strong>WPC</strong>: <code>0.0.3-beta504</code><br>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
     "published_at": "2025-07-27T16:59:36+00:00",
     "type": "beta"
   }

--- a/docs/vector/wpc/beta.json
+++ b/docs/vector/wpc/beta.json
@@ -3,7 +3,7 @@
     "version": "0.0.1-beta479",
     "tag": "1.3.11-beta479",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code>\n<strong>WPC</strong>: <code>0.0.1-beta479</code>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta479</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta479</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta479</code><br>\n<strong>EM</strong>: <code>0.0.1-beta479</code></p>\n",
     "published_at": "2025-07-05T15:07:23+00:00",
     "type": "beta"
   },
@@ -11,7 +11,7 @@
     "version": "0.0.1-beta481",
     "tag": "1.3.11-beta481",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code>\n<strong>WPC</strong>: <code>0.0.1-beta481</code>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta481</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta481</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta481</code><br>\n<strong>EM</strong>: <code>0.0.1-beta481</code></p>\n",
     "published_at": "2025-07-05T16:17:59+00:00",
     "type": "beta"
   },
@@ -19,7 +19,7 @@
     "version": "0.0.1-beta486",
     "tag": "1.3.11-beta486",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code>\n<strong>WPC</strong>: <code>0.0.1-beta486</code>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta486</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta486</code><br>\n<strong>WPC</strong>: <code>0.0.1-beta486</code><br>\n<strong>EM</strong>: <code>0.0.1-beta486</code></p>\n",
     "published_at": "2025-07-08T22:43:34+00:00",
     "type": "beta"
   },
@@ -27,7 +27,7 @@
     "version": "0.0.2-beta493",
     "tag": "1.3.11-beta493",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code>\n<strong>WPC</strong>: <code>0.0.2-beta493</code>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta493</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta493</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta493</code><br>\n<strong>EM</strong>: <code>0.0.1-beta493</code></p>\n",
     "published_at": "2025-07-18T20:12:57+00:00",
     "type": "beta"
   },
@@ -35,7 +35,7 @@
     "version": "0.0.2-beta502",
     "tag": "1.3.11-beta502",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code>\n<strong>WPC</strong>: <code>0.0.2-beta502</code>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-beta502</code><br>\n<strong>Sys11</strong>: <code>1.4.0-beta502</code><br>\n<strong>WPC</strong>: <code>0.0.2-beta502</code><br>\n<strong>EM</strong>: <code>0.0.1-beta502</code></p>\n",
     "published_at": "2025-07-27T16:56:03+00:00",
     "type": "beta"
   },
@@ -43,7 +43,7 @@
     "version": "0.0.3-beta504",
     "tag": "1.3.12-beta504",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code>\n<strong>WPC</strong>: <code>0.0.3-beta504</code>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-beta504</code><br>\n<strong>Sys11</strong>: <code>1.4.1-beta504</code><br>\n<strong>WPC</strong>: <code>0.0.3-beta504</code><br>\n<strong>EM</strong>: <code>0.0.2-beta504</code></p>\n",
     "published_at": "2025-07-27T16:59:36+00:00",
     "type": "beta"
   }

--- a/docs/vector/wpc/dev.json
+++ b/docs/vector/wpc/dev.json
@@ -3,7 +3,7 @@
     "version": "0.0.1-dev83",
     "tag": "1.3.11-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code>\n<strong>WPC</strong>: <code>0.0.1-dev83</code>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev83</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev83</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev83</code><br>\n<strong>EM</strong>: <code>0.0.1-dev83</code></p>\n",
     "published_at": "2025-06-24T01:11:06+00:00",
     "type": "dev"
   },
@@ -11,7 +11,7 @@
     "version": "1.3.10-dev83",
     "tag": "1.3.10-dev83",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "notes": "<p>Version: 1.3.10-dev83\nTrigger: pull_request</p>",
+    "notes": "<p>Version: 1.3.10-dev83<br>\nTrigger: pull_request</p>",
     "published_at": "2025-06-19T02:25:50+00:00",
     "type": "dev"
   },
@@ -19,7 +19,7 @@
     "version": "0.0.1-dev89",
     "tag": "1.3.11-dev89",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code>\n<strong>WPC</strong>: <code>0.0.1-dev89</code>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev89</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev89</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev89</code><br>\n<strong>EM</strong>: <code>0.0.1-dev89</code></p>\n",
     "published_at": "2025-07-05T15:30:41+00:00",
     "type": "dev"
   },
@@ -27,7 +27,7 @@
     "version": "0.0.1-dev91",
     "tag": "1.3.11-dev91",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code>\n<strong>WPC</strong>: <code>0.0.1-dev91</code>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev91</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev91</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev91</code><br>\n<strong>EM</strong>: <code>0.0.1-dev91</code></p>\n",
     "published_at": "2025-07-08T19:03:49+00:00",
     "type": "dev"
   },
@@ -35,7 +35,7 @@
     "version": "0.0.1-dev90",
     "tag": "1.3.11-dev90",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code>\n<strong>WPC</strong>: <code>0.0.1-dev90</code>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev90</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev90</code><br>\n<strong>WPC</strong>: <code>0.0.1-dev90</code><br>\n<strong>EM</strong>: <code>0.0.1-dev90</code></p>\n",
     "published_at": "2025-07-08T18:50:19+00:00",
     "type": "dev"
   },
@@ -43,7 +43,7 @@
     "version": "0.0.2-dev92",
     "tag": "1.3.11-dev92",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code>\n<strong>WPC</strong>: <code>0.0.2-dev92</code>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev92</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev92</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev92</code><br>\n<strong>EM</strong>: <code>0.0.1-dev92</code></p>\n",
     "published_at": "2025-07-12T22:23:49+00:00",
     "type": "dev"
   },
@@ -51,7 +51,7 @@
     "version": "0.0.3-dev93",
     "tag": "1.3.12-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code>\n<strong>WPC</strong>: <code>0.0.3-dev93</code>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev93</code><br>\n<strong>EM</strong>: <code>0.0.2-dev93</code></p>\n",
     "published_at": "2025-07-22T01:56:25+00:00",
     "type": "dev"
   },
@@ -59,7 +59,7 @@
     "version": "0.0.2-dev96",
     "tag": "1.3.11-dev96",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code>\n<strong>WPC</strong>: <code>0.0.2-dev96</code>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev96</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev96</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev96</code><br>\n<strong>EM</strong>: <code>0.0.1-dev96</code></p>\n",
     "published_at": "2025-07-25T03:12:55+00:00",
     "type": "dev"
   },
@@ -67,7 +67,7 @@
     "version": "0.0.2-dev95",
     "tag": "1.3.11-dev95",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code>\n<strong>WPC</strong>: <code>0.0.2-dev95</code>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev95</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev95</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev95</code><br>\n<strong>EM</strong>: <code>0.0.1-dev95</code></p>\n",
     "published_at": "2025-07-22T13:36:02+00:00",
     "type": "dev"
   },
@@ -75,7 +75,7 @@
     "version": "0.0.2-dev94",
     "tag": "1.3.11-dev94",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code>\n<strong>WPC</strong>: <code>0.0.2-dev94</code>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev94</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev94</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev94</code><br>\n<strong>EM</strong>: <code>0.0.1-dev94</code></p>\n",
     "published_at": "2025-07-22T13:20:11+00:00",
     "type": "dev"
   },
@@ -83,7 +83,7 @@
     "version": "0.0.2-dev93",
     "tag": "1.3.11-dev93",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code>\n<strong>WPC</strong>: <code>0.0.2-dev93</code>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.11-dev93</code><br>\n<strong>Sys11</strong>: <code>1.4.0-dev93</code><br>\n<strong>WPC</strong>: <code>0.0.2-dev93</code><br>\n<strong>EM</strong>: <code>0.0.1-dev93</code></p>\n",
     "published_at": "2025-07-22T00:40:35+00:00",
     "type": "dev"
   },
@@ -91,7 +91,7 @@
     "version": "0.0.3-dev98",
     "tag": "1.3.12-dev98",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code>\n<strong>WPC</strong>: <code>0.0.3-dev98</code>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev98</code><br>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
     "published_at": "2025-07-30T12:57:34+00:00",
     "type": "dev"
   },
@@ -99,7 +99,7 @@
     "version": "0.0.3-dev97",
     "tag": "1.3.12-dev97",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_wpc.json",
-    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code>\n<strong>WPC</strong>: <code>0.0.3-dev97</code>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
+    "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev97</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev97</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev97</code><br>\n<strong>EM</strong>: <code>0.0.2-dev97</code></p>\n",
     "published_at": "2025-07-30T12:43:13+00:00",
     "type": "dev"
   }

--- a/docs/vector/wpc/latest.json
+++ b/docs/vector/wpc/latest.json
@@ -2,6 +2,6 @@
   "version": "0.0.3-dev98",
   "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
   "release_page": "https://github.com/warped-pinball/vector/releases/tag/1.3.12-dev98",
-  "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code>\n<strong>WPC</strong>: <code>0.0.3-dev98</code>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
+  "notes": "<h2>Versions</h2>\n<p><strong>Vector</strong>: <code>1.3.12-dev98</code><br>\n<strong>Sys11</strong>: <code>1.4.1-dev98</code><br>\n<strong>WPC</strong>: <code>0.0.3-dev98</code><br>\n<strong>EM</strong>: <code>0.0.2-dev98</code></p>\n",
   "published_at": "2025-07-30T12:57:34+00:00"
 }

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -63,9 +63,10 @@ def release_notes_to_html(text):
     """Convert Markdown release notes to sanitized HTML without images."""
     if not text:
         return ""
-    html = markdown.markdown(text)
+    # use the nl2br extension so single newlines become ``<br>`` tags
+    html = markdown.markdown(text, extensions=["nl2br"])
     allowed_tags = set(bleach.sanitizer.ALLOWED_TAGS).union(
-        {"p", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6"}
+        {"p", "pre", "code", "h1", "h2", "h3", "h4", "h5", "h6", "br"}
     ) - {"img"}
     return bleach.clean(
         html,

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -90,6 +90,12 @@ def test_release_notes_to_html_sanitizes_and_strips_images():
     assert "Hello" in html
 
 
+def test_release_notes_to_html_converts_newlines_to_br():
+    md = "Line 1\nLine 2"
+    html = generate.release_notes_to_html(md)
+    assert "<br" in html
+
+
 
 def test_build_latest_release_data_uses_tag():
     entry = {


### PR DESCRIPTION
## Summary
- preserve newline characters in release notes by using the `nl2br` markdown extension
- allow `<br>` tags through HTML sanitizer
- add tests for newline handling in release notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8bb98a7c8330b65c9b298ef77460