### PR TITLE
flasher: let Android/unsupported browsers try anyway

### DIFF
--- a/docs/builds.json
+++ b/docs/builds.json
@@ -617,6 +617,13 @@
   },
   {
     "product": "sys11",
+    "version": "1.3.4-beta358",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
+    "sha256": "4c8f7a690f04615f793845fff89f7a5e5f2dffe57cdca9eb4ec10d08a22411a2"
+  },
+  {
+    "product": "sys11",
     "version": "1.3.5-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",

--- a/docs/download_counts.json
+++ b/docs/download_counts.json
@@ -4,615 +4,622 @@
     "version": "0.4.0-dev24",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev22",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
-    "download_count": 108
+    "download_count": 109
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev25",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "0.3.0-beta-116",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta123",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta126",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev28",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta130",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "0.4.2-dev30",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.1-beta135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev31",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "0.4.2-beta139",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev32",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.3-beta145",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev35",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "0.4.5-dev33",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev34",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta149",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
-    "download_count": 93
+    "download_count": 94
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev43",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta203",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev45",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev46",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev44",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta211",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta225",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.1.0-beta227",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev51",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev50",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta235",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta246",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta251",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta254",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev54",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta258",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev57",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev61",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.1-beta310",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta320",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta319",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev62",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta324",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta327",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
-    "download_count": 87
+    "download_count": 88
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev63",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.3-beta330",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
-    "download_count": 88
+    "download_count": 89
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev66",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev65",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta338",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev70",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
+    "download_count": 78
+  },
+  {
+    "product": "sys11",
+    "version": "1.3.4-beta358",
+    "type": "beta",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
     "download_count": 77
   },
   {
@@ -620,6999 +627,6999 @@
     "version": "1.3.5-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta361",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
-    "download_count": 249
+    "download_count": 250
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta363",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta372",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta376",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.7-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta378",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev74",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.7",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
-    "download_count": 197
+    "download_count": 198
   },
   {
     "product": "sys11",
     "version": "1.3.7-beta381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
-    "download_count": 98
+    "download_count": 99
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev78",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev77",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev76",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta386",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta394",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev80",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta396",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev81",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta399",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.9",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
-    "download_count": 98
+    "download_count": 99
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev82",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta404",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "download_count": 75
+    "download_count": 76
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "download_count": 75
+    "download_count": 76
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta408",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "em",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.3.10",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
-    "download_count": 93
+    "download_count": 94
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "download_count": 71
+    "download_count": 72
   },
   {
     "product": "wpc",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "download_count": 71
+    "download_count": 72
   },
   {
     "product": "em",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.3.10-beta419",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "download_count": 75
+    "download_count": 76
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "em",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "em",
     "version": "0.0.1-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_wpc.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "em",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_wpc.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "em",
     "version": "0.0.1-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_wpc.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "em",
     "version": "0.0.1-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_wpc.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "em",
     "version": "0.0.1-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_wpc.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "em",
     "version": "0.0.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "em",
     "version": "0.0.1-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_wpc.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "em",
     "version": "0.0.1-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "em",
     "version": "0.0.2-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_wpc.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "em",
     "version": "0.0.2-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.1-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.2-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "wpc",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update_wpc.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "em",
     "version": "0.0.3-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.3-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "0.0.3-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "wpc",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update_em.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.0.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update_em.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.0.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.1-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.0.1-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.1-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.2-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.1-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.1-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.2-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.3-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update_wpc.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "em",
     "version": "1.0.1-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.2-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.2-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.3-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.4-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.3-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.4-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.4-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.1.6-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.5-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.1.6-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update_wpc.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "em",
     "version": "1.0.1-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update_em.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.0.1-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.2.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.2.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update_wpc.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "em",
     "version": "1.2.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update_em.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.2.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.2.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.2.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.2.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update_wpc.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "em",
     "version": "1.2.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update_em.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_wpc.json",
-    "download_count": 34
+    "download_count": 35
   },
   {
     "product": "em",
     "version": "1.2.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_em.json",
-    "download_count": 34
+    "download_count": 35
   },
   {
     "product": "data_east",
     "version": "0.0.0-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_data_east.json",
-    "download_count": 34
+    "download_count": 35
   },
   {
     "product": "whitestar",
     "version": "0.0.0-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_whitestar.json",
-    "download_count": 33
+    "download_count": 34
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.2.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_em.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "data_east",
     "version": "0.0.0-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.0.0-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_whitestar.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "wpc",
     "version": "1.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_wpc.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "em",
     "version": "1.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_whitestar.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_wpc.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "em",
     "version": "1.3.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_em.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.3.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.3.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.3.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.3.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.4.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_wpc.json",
-    "download_count": 31
+    "download_count": 32
   },
   {
     "product": "em",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.4.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.4.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.4.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.4.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_wpc.json",
-    "download_count": 32
+    "download_count": 33
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.5.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_wpc.json",
-    "download_count": 32
+    "download_count": 33
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.2-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.2-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.5.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.5.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.5.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_whitestar.json",
-    "download_count": 19
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.1-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.0-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.0-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.0-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.0-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.3-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.3-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.2-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.4-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.3-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.5-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.4-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.4-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update.json",
-    "download_count": 47
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.7.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_wpc.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "em",
     "version": "1.6.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "1.0.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.5-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.4-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.7-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.7-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.4-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.7-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.8-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.8-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.4-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_wpc.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "em",
     "version": "1.6.4-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_em.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_data_east.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_whitestar.json",
-    "download_count": 9
+    "download_count": 10
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.4-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   }
 ]

--- a/docs/download_counts.json
+++ b/docs/download_counts.json
@@ -4,7622 +4,7622 @@
     "version": "0.4.0-dev24",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev22",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
-    "download_count": 109
+    "download_count": 110
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev25",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.3.0-beta-116",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta123",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta126",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev28",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta130",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.2-dev30",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.1-beta135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev31",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.2-beta139",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev32",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.3-beta145",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev35",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.5-dev33",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev34",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta149",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
-    "download_count": 94
+    "download_count": 95
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev43",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta203",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev45",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev46",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "download_count": 83
+    "download_count": 84
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev44",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta211",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta225",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.1.0-beta227",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev51",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev50",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta235",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta246",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta251",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta254",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev54",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta258",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev57",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev61",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.1-beta310",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta320",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta319",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev62",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta324",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta327",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
-    "download_count": 88
+    "download_count": 89
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev63",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.3-beta330",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
-    "download_count": 89
+    "download_count": 90
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev66",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev65",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta338",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev70",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta358",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta361",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
-    "download_count": 250
+    "download_count": 251
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta363",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta372",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta376",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.7-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta378",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev74",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.3.7",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
-    "download_count": 198
+    "download_count": 199
   },
   {
     "product": "sys11",
     "version": "1.3.7-beta381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.8",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
-    "download_count": 99
+    "download_count": 100
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev78",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev77",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev76",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta386",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta394",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev80",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta396",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev81",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta399",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.9",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
-    "download_count": 99
+    "download_count": 100
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev82",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta404",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta408",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "download_count": 63
+    "download_count": 64
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "download_count": 63
+    "download_count": 64
   },
   {
     "product": "em",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.3.10",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
-    "download_count": 94
+    "download_count": 95
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "download_count": 72
+    "download_count": 73
   },
   {
     "product": "wpc",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "download_count": 72
+    "download_count": 73
   },
   {
     "product": "em",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.3.10-beta419",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "download_count": 76
+    "download_count": 77
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "download_count": 63
+    "download_count": 64
   },
   {
     "product": "em",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "em",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.1-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "em",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_wpc.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "em",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_wpc.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "em",
     "version": "0.0.1-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_wpc.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "em",
     "version": "0.0.1-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_wpc.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "em",
     "version": "0.0.1-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.1-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_wpc.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "em",
     "version": "0.0.1-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "em",
     "version": "0.0.2-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_wpc.json",
-    "download_count": 56
+    "download_count": 57
   },
   {
     "product": "em",
     "version": "0.0.2-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.1-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.3-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.2-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update.json",
-    "download_count": 54
+    "download_count": 55
   },
   {
     "product": "wpc",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update_wpc.json",
-    "download_count": 54
+    "download_count": 55
   },
   {
     "product": "em",
     "version": "0.0.3-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.3-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "0.0.3-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update.json",
-    "download_count": 54
+    "download_count": 55
   },
   {
     "product": "wpc",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.0.1-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update_em.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.1-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update_em.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.1-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.1-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.2-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.1-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.1-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.2-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.3-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.2-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.2-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.3-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.4-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.3-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.4-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update_wpc.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "em",
     "version": "1.0.1-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.4-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update_wpc.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "em",
     "version": "1.0.1-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.6-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.5-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.6",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.6-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.0.1-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.2.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.2.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.2.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.2.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.2.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.2.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.2.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update_wpc.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "em",
     "version": "1.2.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update_em.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_wpc.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "em",
     "version": "1.2.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_em.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "data_east",
     "version": "0.0.0-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_data_east.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "whitestar",
     "version": "0.0.0-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_whitestar.json",
-    "download_count": 34
+    "download_count": 35
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_wpc.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "em",
     "version": "1.2.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_em.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "data_east",
     "version": "0.0.0-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.0.0-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_whitestar.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update.json",
-    "download_count": 31
+    "download_count": 32
   },
   {
     "product": "wpc",
     "version": "1.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_em.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "data_east",
     "version": "0.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_data_east.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "whitestar",
     "version": "0.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_whitestar.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_wpc.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "em",
     "version": "1.3.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_em.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_data_east.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_whitestar.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.3.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.3.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.3.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.3.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.4.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.4.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_em.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.4.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.4.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_whitestar.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_wpc.json",
-    "download_count": 32
+    "download_count": 33
   },
   {
     "product": "em",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.4.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.4.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.5.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_wpc.json",
-    "download_count": 33
+    "download_count": 34
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.5.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_wpc.json",
-    "download_count": 33
+    "download_count": 34
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.2-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.2-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.5.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.5.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_wpc.json",
-    "download_count": 47
+    "download_count": 48
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.5.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.5.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.1-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.0-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.3-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.3-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.2-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.4-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.4-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.3-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.5-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.4-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.4-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update.json",
-    "download_count": 49
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.7.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_wpc.json",
-    "download_count": 31
+    "download_count": 33
   },
   {
     "product": "em",
     "version": "1.6.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_em.json",
-    "download_count": 21
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "1.0.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_data_east.json",
-    "download_count": 23
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.5-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.4-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.7-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.7-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.4-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.7-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.8-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.8-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.4-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.4-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_wpc.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "em",
     "version": "1.6.4-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_em.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_data_east.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_whitestar.json",
-    "download_count": 10
+    "download_count": 11
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.4-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   }
 ]

--- a/docs/download_counts.json
+++ b/docs/download_counts.json
@@ -4,7622 +4,7622 @@
     "version": "0.4.0-dev24",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev24/update.json",
-    "download_count": 83
+    "download_count": 84
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev22",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev22/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0/update.json",
-    "download_count": 110
+    "download_count": 111
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev25",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev25/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.3.0-beta-116",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.3.0-beta-116/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta123",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta123/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta126",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta126/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev28",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev28/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.0-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-dev29/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.0-beta130",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.0-beta130/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.2-dev30",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-dev30/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.1-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-dev29/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.1-beta135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.1-beta135/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev31",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev31/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.3-dev29",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-dev29/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.2-beta139",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.2-beta139/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev32",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev32/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "0.4.3-beta145",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.3-beta145/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev35",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev35/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.5-dev33",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.5-dev33/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.4-dev34",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-dev34/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta149",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta149/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "0.4.4-beta160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/0.4.4-beta160/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0/update.json",
-    "download_count": 95
+    "download_count": 96
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev43",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev43/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta203",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta203/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev45",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev45/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev47/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev46",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev46/update.json",
-    "download_count": 84
+    "download_count": 85
   },
   {
     "product": "sys11",
     "version": "1.0.0-dev44",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-dev44/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta211",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta211/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.0.0-beta225",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.0.0-beta225/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev47",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev47/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev49/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.1.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-dev48/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.1.0-beta227",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.1.0-beta227/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0/update.json",
-    "download_count": 83
+    "download_count": 84
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev53/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev52/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev51",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev51/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev50",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev50/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev49",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev49/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-dev48",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-dev48/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta235",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta235/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta246",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta246/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta247/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta251",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta251/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev52",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev52/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.2.0-beta254",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.2.0-beta254/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev55/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev54",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev54/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev53/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta258",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta258/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev58/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev55",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev55/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev59/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev57",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev57/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.0-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-dev56/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.0-beta262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.0-beta262/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev61",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev61/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev60/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev60",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev60/update.json",
-    "download_count": 83
+    "download_count": 84
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev59",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev59/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.1-dev56",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-dev56/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.1-beta310",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.1-beta310/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev58",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev58/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev53",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev53/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta320",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta320/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta319",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta319/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.3.2-dev62",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-dev62/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta324",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta324/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.2-beta327",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.2-beta327/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev64/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3/update.json",
-    "download_count": 89
+    "download_count": 90
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev64",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev64/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.3-dev63",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-dev63/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.3-beta330",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.3-beta330/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4/update.json",
-    "download_count": 90
+    "download_count": 91
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev68/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev67/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev66",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev66/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.4-dev65",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-dev65/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta338",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta338/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev70",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev70/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.4-beta358",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev67",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta361",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev68/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5/update.json",
-    "download_count": 251
+    "download_count": 252
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev68",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev68/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta363",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta363/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.5-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev72/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.5-beta372",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta372/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta376",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta376/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.7-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-dev73/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev73",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev73/update.json",
-    "download_count": 80
+    "download_count": 81
   },
   {
     "product": "sys11",
     "version": "1.3.6-dev72",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-dev72/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.6-beta378",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.6-beta378/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev74",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev74/update.json",
-    "download_count": 82
+    "download_count": 83
   },
   {
     "product": "sys11",
     "version": "1.3.7",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7/update.json",
-    "download_count": 199
+    "download_count": 200
   },
   {
     "product": "sys11",
     "version": "1.3.7-beta381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.7-beta381/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.3.8",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8/update.json",
-    "download_count": 100
+    "download_count": 101
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev78",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev78/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev77",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev77/update.json",
-    "download_count": 78
+    "download_count": 79
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev76",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev76/update.json",
-    "download_count": 81
+    "download_count": 82
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta386",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta386/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta394",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta394/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8-dev80",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-dev80/update.json",
-    "download_count": 83
+    "download_count": 84
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta396",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta396/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev81",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev81/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.8-beta399",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.8-beta399/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.9",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9/update.json",
-    "download_count": 100
+    "download_count": 101
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev82",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev82/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta404",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta404/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev84/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.9-dev84",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-dev84/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.3.9-beta408",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.9-beta408/update.json",
-    "download_count": 79
+    "download_count": 80
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update.json",
-    "download_count": 64
+    "download_count": 65
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_wpc.json",
-    "download_count": 64
+    "download_count": 65
   },
   {
     "product": "em",
     "version": "0.0.1-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev83/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.3.10",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10/update.json",
-    "download_count": 95
+    "download_count": 96
   },
   {
     "product": "sys11",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update.json",
-    "download_count": 73
+    "download_count": 74
   },
   {
     "product": "wpc",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_wpc.json",
-    "download_count": 73
+    "download_count": 74
   },
   {
     "product": "em",
     "version": "1.3.10-dev83",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-dev83/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.3.10-beta419",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.10-beta419/update.json",
-    "download_count": 77
+    "download_count": 78
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update.json",
-    "download_count": 63
+    "download_count": 64
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_wpc.json",
-    "download_count": 64
+    "download_count": 65
   },
   {
     "product": "em",
     "version": "0.0.1-dev89",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev89/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update.json",
-    "download_count": 63
+    "download_count": 64
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_wpc.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "em",
     "version": "0.0.1-beta479",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta479/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_wpc.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "em",
     "version": "0.0.1-dev91",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev91/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_wpc.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "em",
     "version": "0.0.1-dev90",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev90/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_wpc.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "em",
     "version": "0.0.1-beta481",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta481/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-dev92",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev92/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_wpc.json",
-    "download_count": 62
+    "download_count": 63
   },
   {
     "product": "em",
     "version": "0.0.1-beta486",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta486/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_wpc.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "em",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev93/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_wpc.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "em",
     "version": "0.0.1-dev96",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev96/update_em.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_wpc.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "em",
     "version": "0.0.1-dev95",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev95/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_wpc.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "em",
     "version": "0.0.1-dev94",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev94/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.2-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-dev93",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev93/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.1-beta493",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta493/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.0-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update.json",
-    "download_count": 59
+    "download_count": 60
   },
   {
     "product": "wpc",
     "version": "0.0.2-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_wpc.json",
-    "download_count": 58
+    "download_count": 59
   },
   {
     "product": "em",
     "version": "0.0.1-beta502",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-beta502/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev99",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev99/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_wpc.json",
-    "download_count": 60
+    "download_count": 61
   },
   {
     "product": "em",
     "version": "0.0.2-dev98",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev98/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev97",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev97/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_wpc.json",
-    "download_count": 57
+    "download_count": 58
   },
   {
     "product": "em",
     "version": "0.0.2-beta504",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta504/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev104",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev104/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev102",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev102/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev101",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev101/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev100",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev100/update_em.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-beta518",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta518/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.0-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.1-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.1-dev103",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.11-dev103/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-beta533",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta533/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update_wpc.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "em",
     "version": "0.0.2-dev108",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev108/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev107",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev107/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update.json",
-    "download_count": 61
+    "download_count": 62
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev106",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev106/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev105",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev105/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-beta536",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta536/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev113",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev113/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev112",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev112/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev111",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev111/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev110",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev110/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev109",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev109/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta559",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta559/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update_wpc.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "em",
     "version": "0.0.2-dev115",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev115/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev114",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev114/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-beta600",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta600/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev116",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev116/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta605",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta605/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev122",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev122/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev119",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev119/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-dev118",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev118/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev117",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev117/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta610/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-beta623",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta623/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.3-dev124",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev124/update_em.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.2-dev123",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-dev123/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "0.0.3-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.2-beta624",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.12-beta624/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "0.0.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev125",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev125/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update.json",
-    "download_count": 54
+    "download_count": 55
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update_wpc.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "em",
     "version": "0.0.3-beta630",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta630/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update_wpc.json",
-    "download_count": 53
+    "download_count": 54
   },
   {
     "product": "em",
     "version": "0.0.3-beta629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta629/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev131",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev131/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-dev130",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev130/update_em.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-dev129",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev129/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev128",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev128/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev127",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev127/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev126",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev126/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-beta635",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta635/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta647",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta647/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev137",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev137/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev136",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev136/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev135",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev135/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-dev134",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev134/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev133",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev133/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-dev132",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev132/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-beta649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta649/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta702",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta702/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.0.0-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta704",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta704/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update_wpc.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "em",
     "version": "0.0.3-dev138",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-dev138/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-beta705",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.4.1-beta705/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.4.1-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "0.0.3-beta707",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta707/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update.json",
-    "download_count": 55
+    "download_count": 56
   },
   {
     "product": "wpc",
     "version": "1.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0/update_em.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.1-dev140",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev140/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "wpc",
     "version": "1.1.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "1.0.0-dev139",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev139/update_em.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "1.0.0-beta709",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta709/update_em.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update_wpc.json",
-    "download_count": 50
+    "download_count": 51
   },
   {
     "product": "em",
     "version": "0.0.3-beta708",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta708/update_em.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.1-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1-dev141",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-dev141/update_em.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "wpc",
     "version": "1.1.0-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "1.0.1-beta715",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta715/update_em.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.1-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1-beta718",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.0-beta718/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2/update_em.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.2-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-dev143",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev143/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.1-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1-dev142",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-dev142/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.1-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1-beta720",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta720/update_em.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.2-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1-beta727",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.2-beta727/update_em.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "wpc",
     "version": "1.1.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update_wpc.json",
-    "download_count": 52
+    "download_count": 53
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.3-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.0.1-dev145",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev145/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.2-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.0.1-dev144",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-dev144/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "wpc",
     "version": "1.1.2-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-beta729",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta729/update_em.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.3-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-beta733",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.3-beta733/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.4-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update_wpc.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "em",
     "version": "1.0.1-dev146",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-dev146/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "wpc",
     "version": "1.1.3-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update_wpc.json",
-    "download_count": 44
+    "download_count": 45
   },
   {
     "product": "em",
     "version": "1.0.1-beta734",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta734/update_em.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.4-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-beta743",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.4-beta743/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev147/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-dev147",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-dev147/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.4-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update_wpc.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "em",
     "version": "1.0.1-beta744",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.5-beta744/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev148/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update_wpc.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-dev149",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev149/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.5-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-dev148",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-dev148/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.5-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update_wpc.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "em",
     "version": "1.0.1-beta749",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.6-beta749/update_em.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "sys11",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.6",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.0.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.0.1-dev153",
     "type": "dev",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-dev153/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-beta762",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta762/update_em.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-beta771",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta771/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.0.1-beta782",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta782/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.5.0-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.1.6-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.0.1-beta784",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.5.7-beta784/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.2.0-beta803",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta803/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update.json",
-    "download_count": 42
+    "download_count": 43
   },
   {
     "product": "wpc",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update_wpc.json",
-    "download_count": 49
+    "download_count": 50
   },
   {
     "product": "em",
     "version": "1.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0/update_em.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update_wpc.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "em",
     "version": "1.2.0-beta804",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta804/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update_wpc.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "em",
     "version": "1.2.0-beta819",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta819/update_em.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.2.0-beta820",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta820/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.2.0-beta828",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.0-beta828/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "wpc",
     "version": "1.2.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update_wpc.json",
-    "download_count": 45
+    "download_count": 46
   },
   {
     "product": "em",
     "version": "1.2.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update.json",
-    "download_count": 38
+    "download_count": 39
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update_wpc.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "em",
     "version": "1.2.1-beta830",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta830/update_em.json",
-    "download_count": 39
+    "download_count": 40
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update_wpc.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "em",
     "version": "1.2.1-beta848",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta848/update_em.json",
-    "download_count": 37
+    "download_count": 38
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update.json",
-    "download_count": 40
+    "download_count": 41
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_wpc.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "em",
     "version": "1.2.1-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_em.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "data_east",
     "version": "0.0.0-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_data_east.json",
-    "download_count": 36
+    "download_count": 37
   },
   {
     "product": "whitestar",
     "version": "0.0.0-beta896",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta896/update_whitestar.json",
-    "download_count": 35
+    "download_count": 36
   },
   {
     "product": "sys11",
     "version": "1.6.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "wpc",
     "version": "1.2.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_wpc.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "em",
     "version": "1.2.1-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_em.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "data_east",
     "version": "0.0.0-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_data_east.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "whitestar",
     "version": "0.0.0-beta899",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.6.1-beta899/update_whitestar.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update.json",
-    "download_count": 32
+    "download_count": 33
   },
   {
     "product": "wpc",
     "version": "1.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_wpc.json",
-    "download_count": 43
+    "download_count": 44
   },
   {
     "product": "em",
     "version": "1.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_em.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "data_east",
     "version": "0.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_data_east.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "whitestar",
     "version": "0.1.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0/update_whitestar.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_wpc.json",
-    "download_count": 31
+    "download_count": 32
   },
   {
     "product": "em",
     "version": "1.3.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_em.json",
-    "download_count": 31
+    "download_count": 32
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_data_east.json",
-    "download_count": 30
+    "download_count": 31
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta904",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta904/update_whitestar.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.3.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta909",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta909/update_whitestar.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.3.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta910",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta910/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.3.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta944",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta944/update_whitestar.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.3.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.3.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.1.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.1.0-beta946",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.7.0-beta946/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "wpc",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_wpc.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "em",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_data_east.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "whitestar",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.4.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.4.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_em.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta950",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta950/update_whitestar.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.4.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.4.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_em.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_data_east.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta953",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta953/update_whitestar.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta958",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.0-beta958/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.4.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_wpc.json",
-    "download_count": 33
+    "download_count": 34
   },
   {
     "product": "em",
     "version": "1.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_wpc.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "em",
     "version": "1.4.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_data_east.json",
-    "download_count": 26
+    "download_count": 27
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta960",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta960/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta966",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta966/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta974",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta974/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta979",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta979/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta988",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta988/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_wpc.json",
-    "download_count": 27
+    "download_count": 28
   },
   {
     "product": "em",
     "version": "1.4.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta991",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta991/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta990",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta990/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_wpc.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "em",
     "version": "1.4.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta1004",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1004/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.7.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.4.1-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.4.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.2.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.2.0-beta1003",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.8.1-beta1003/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update.json",
-    "download_count": 41
+    "download_count": 42
   },
   {
     "product": "wpc",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_wpc.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_em.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0/update_whitestar.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.5.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_em.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1006",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1006/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.5.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1010",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1010/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.5.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.5.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_data_east.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1009",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1009/update_whitestar.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1016",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.0-beta1016/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "wpc",
     "version": "1.5.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_wpc.json",
-    "download_count": 34
+    "download_count": 35
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1018",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.1-beta1018/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.5.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1030",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1030/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.1-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1032",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1032/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "wpc",
     "version": "1.5.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_wpc.json",
-    "download_count": 34
+    "download_count": 35
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2/update_whitestar.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.2-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_wpc.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "em",
     "version": "1.5.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_data_east.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1034",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1034/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.2-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.0-beta1051",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.2-beta1051/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "wpc",
     "version": "1.5.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_wpc.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "em",
     "version": "1.5.0-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1055",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1055/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1054",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1054/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.8.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1053",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.3-beta1053/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update.json",
-    "download_count": 29
+    "download_count": 30
   },
   {
     "product": "wpc",
     "version": "1.5.3",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_wpc.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "em",
     "version": "1.5.0-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_em.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_data_east.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1064",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1064/update_whitestar.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1074",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1074/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_wpc.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "em",
     "version": "1.5.0-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1095",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1095/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.8.2-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.5.3-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_em.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "data_east",
     "version": "0.3.1-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_data_east.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "whitestar",
     "version": "0.3.1-beta1094",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.9.4-beta1094/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.9.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "wpc",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_wpc.json",
-    "download_count": 48
+    "download_count": 49
   },
   {
     "product": "em",
     "version": "1.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.4.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0/update_whitestar.json",
-    "download_count": 20
+    "download_count": 21
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_wpc.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "em",
     "version": "1.5.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1097",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1097/update_whitestar.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1136",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1136/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1135",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1135/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1158",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1158/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1160",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1160/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1162",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1162/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1169",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1169/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.5.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1172",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1172/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1179",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1179/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1181",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1181/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1183",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1183/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1204",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1204/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1212",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1212/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1247",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1247/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1252",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1252/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1257",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1257/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1262",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1262/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1264",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1264/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1266",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1266/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1270",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1270/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1279",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1279/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1293",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1293/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1297",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1297/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1306",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1306/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1309",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1309/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1308",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1308/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.5.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_em.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1311",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1311/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_wpc.json",
-    "download_count": 24
+    "download_count": 25
   },
   {
     "product": "em",
     "version": "1.5.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_em.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_data_east.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1342",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1342/update_whitestar.json",
-    "download_count": 22
+    "download_count": 23
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1362",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1362/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1380",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1380/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1381",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1381/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.9.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.6.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.5.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "0.4.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.4.0-beta1387",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.10.0-beta1387/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.6.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_data_east.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1397",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1397/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.6.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1403",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1403/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1405",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1405/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update.json",
-    "download_count": 46
+    "download_count": 47
   },
   {
     "product": "wpc",
     "version": "1.7.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_wpc.json",
-    "download_count": 28
+    "download_count": 29
   },
   {
     "product": "em",
     "version": "1.6.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "1.0.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_data_east.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "whitestar",
     "version": "0.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0/update_whitestar.json",
-    "download_count": 22
+    "download_count": 24
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_em.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1407",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1407/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1415",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1415/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1417",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1417/update_whitestar.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1422",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1422/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1424",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1424/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1433",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1433/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_em.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "data_east",
     "version": "1.0.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1439",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.0-beta1439/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.1-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1473",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.1-beta1473/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1478",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.3-beta1478/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.0-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1485",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1485/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.0-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1500",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.4-beta1500/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1513",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1513/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.0-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1514",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.5-beta1514/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update.json",
-    "download_count": 19
+    "download_count": 20
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_wpc.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "em",
     "version": "1.6.2-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1517",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1517/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.2-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1516",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1516/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update.json",
-    "download_count": 21
+    "download_count": 22
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.2-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_data_east.json",
-    "download_count": 17
+    "download_count": 18
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1528",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1528/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.2-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.1-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1537",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.6-beta1537/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.3-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.3-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.2-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1548",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.8-beta1548/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.4-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.4-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.3-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1553",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.9-beta1553/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.5-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.4-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.4-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1560",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1560/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.2",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update.json",
-    "download_count": 51
+    "download_count": 52
   },
   {
     "product": "wpc",
     "version": "1.7.5",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_wpc.json",
-    "download_count": 33
+    "download_count": 34
   },
   {
     "product": "em",
     "version": "1.6.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_em.json",
-    "download_count": 23
+    "download_count": 24
   },
   {
     "product": "data_east",
     "version": "1.0.4",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_data_east.json",
-    "download_count": 25
+    "download_count": 26
   },
   {
     "product": "whitestar",
     "version": "0.5.0",
     "type": "production",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10/update_whitestar.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "sys11",
     "version": "1.10.2-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.5-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.4-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1568",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.10-beta1568/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.7-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.7-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1607",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.13-beta1607/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_wpc.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "em",
     "version": "1.6.4-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_em.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "data_east",
     "version": "1.0.7-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_data_east.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1610",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.14-beta1610/update_whitestar.json",
-    "download_count": 16
+    "download_count": 17
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.8-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1629",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1629/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.4-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.8-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1632",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.15-beta1632/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.3-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.8-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.4-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1638",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.17-beta1638/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1641",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1641/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1642",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1642/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.4-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1644",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.19-beta1644/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.9-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1646",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.20-beta1646/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_wpc.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "em",
     "version": "1.6.4-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_em.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_data_east.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1649",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1649/update_whitestar.json",
-    "download_count": 14
+    "download_count": 15
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1653",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1653/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1659",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1659/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.5-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "wpc",
     "version": "1.7.9-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_wpc.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "em",
     "version": "1.6.4-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_em.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "data_east",
     "version": "1.0.10-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_data_east.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "whitestar",
     "version": "0.5.0-beta1664",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.21-beta1664/update_whitestar.json",
-    "download_count": 12
+    "download_count": 13
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_wpc.json",
-    "download_count": 18
+    "download_count": 19
   },
   {
     "product": "em",
     "version": "1.6.4-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1668",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1668/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1675",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.22-beta1675/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_wpc.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "em",
     "version": "1.6.4-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_em.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_data_east.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1680",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.23-beta1680/update_whitestar.json",
-    "download_count": 13
+    "download_count": 14
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_wpc.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "em",
     "version": "1.6.4-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_em.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_data_east.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1689",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1689/update_whitestar.json",
-    "download_count": 11
+    "download_count": 12
   },
   {
     "product": "sys11",
     "version": "1.10.6-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "wpc",
     "version": "1.7.10-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_wpc.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "em",
     "version": "1.6.4-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_em.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "data_east",
     "version": "1.0.11-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_data_east.json",
-    "download_count": 15
+    "download_count": 16
   },
   {
     "product": "whitestar",
     "version": "0.5.1-beta1700",
     "type": "beta",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.11.24-beta1700/update_whitestar.json",
-    "download_count": 15
+    "download_count": 16
   }
 ]

--- a/docs/flasher.html
+++ b/docs/flasher.html
@@ -20,17 +20,19 @@
       <p class="text-base-content/70 mt-2">
         Update your Vector board straight from this page over a USB cable — no downloads, no drivers.
       </p>
+      <p class="text-base-content/50 text-sm mt-1">
+        Works on desktop computers only (Chrome, Edge, Brave, or Opera). Phones and tablets aren't supported.
+      </p>
       <a href="./index.html" class="link link-primary text-sm">← Back to the firmware changelog</a>
     </div>
 
     <!-- Unsupported-browser banner (shown by JS) -->
-    <div id="unsupported" class="alert alert-warning shadow-lg mb-6 hidden flex-col items-start sm:flex-row sm:items-center">
+    <div id="unsupported" class="alert alert-error shadow-lg mb-6 hidden">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-      <div class="flex-1">
-        <h3 class="font-bold">Your browser may not be able to flash over USB</h3>
+      <div>
+        <h3 class="font-bold">This flasher only works on desktop computers</h3>
         <div id="unsupported-detail" class="text-sm"></div>
       </div>
-      <button id="btn-try-anyway" class="btn btn-sm btn-neutral shrink-0">Try anyway</button>
     </div>
 
     <!-- Main app (shown when supported) -->

--- a/docs/flasher.html
+++ b/docs/flasher.html
@@ -24,12 +24,13 @@
     </div>
 
     <!-- Unsupported-browser banner (shown by JS) -->
-    <div id="unsupported" class="alert alert-error shadow-lg mb-6 hidden">
+    <div id="unsupported" class="alert alert-warning shadow-lg mb-6 hidden flex-col items-start sm:flex-row sm:items-center">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-      <div>
-        <h3 class="font-bold">Your browser can’t flash over USB</h3>
+      <div class="flex-1">
+        <h3 class="font-bold">Your browser may not be able to flash over USB</h3>
         <div id="unsupported-detail" class="text-sm"></div>
       </div>
+      <button id="btn-try-anyway" class="btn btn-sm btn-neutral shrink-0">Try anyway</button>
     </div>
 
     <!-- Main app (shown when supported) -->

--- a/docs/flasher/app.js
+++ b/docs/flasher/app.js
@@ -24,7 +24,6 @@ const $ = (id) => document.getElementById(id);
 const el = {
   unsupported: $("unsupported"),
   unsupportedDetail: $("unsupported-detail"),
-  btnTryAnyway: $("btn-try-anyway"),
   app: $("app"),
   steps: $("steps"),
   progressWrap: $("progress-wrap"),
@@ -154,30 +153,19 @@ function checkSupport() {
   if (hasUsb && hasSerial) return true;
 
   const ua = navigator.userAgent;
-  const isAndroid = /Android/.test(ua);
+  const isMobile = /Android|iPhone|iPad|iPod/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
   let detail =
-    "Flashing needs the WebUSB and Web Serial APIs, which are only available in " +
-    "Chromium-based browsers on desktop (Chrome, Edge, Brave, Opera) or Android Chrome. " +
-    "If you think this is wrong, tap “Try anyway” to continue.";
-  if (/iPhone|iPad|iPod/.test(ua) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)) {
+    "Flashing needs the WebUSB and Web Serial APIs, which are only available in a " +
+    "Chromium-based desktop browser. Please use Chrome, Edge, Brave, or Opera on a desktop computer.";
+  if (isMobile) {
     detail =
-      "iPhone and iPad can’t do this — every iOS browser is forced onto Apple’s WebKit engine, " +
-      "which has no WebUSB or Web Serial support. Please use a desktop computer running Chrome, Edge, Brave, or Opera.";
-  } else if (isAndroid) {
-    // Android Chrome has WebUSB but not Web Serial, so the all-or-nothing check
-    // above fails. Board auto-detect needs Web Serial, so the workflow is limited
-    // on Android, but allow proceeding in case detection is wrong on this device.
-    detail =
-      "On Android, Chrome supports WebUSB but not the Web Serial API, which the " +
-      "board auto-detect step relies on — so flashing may not fully work here, and a " +
-      "desktop computer running Chrome, Edge, Brave, or Opera is recommended. " +
-      "If you think this is wrong, tap “Try anyway” to continue.";
+      "Phones and tablets can’t flash over USB — the required browser APIs aren’t available on mobile. " +
+      "Please use Chrome, Edge, Brave, or Opera on a desktop computer.";
   } else if (/Firefox/.test(ua)) {
-    detail = "Firefox does not support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera. " +
-      "If you think this is wrong, tap “Try anyway” to continue.";
+    detail = "Firefox doesn’t support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera on a desktop computer.";
   } else if (/Safari/.test(ua) && !/Chrome/.test(ua)) {
-    detail = "Safari does not support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera. " +
-      "If you think this is wrong, tap “Try anyway” to continue.";
+    detail = "Safari doesn’t support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera on a desktop computer.";
   }
   el.unsupportedDetail.textContent = detail;
   el.unsupported.classList.remove("hidden");
@@ -314,13 +302,6 @@ async function connectAndDetect() {
   clearSteps();
   el.statusAlert.classList.add("hidden");
   try {
-    if (!("serial" in navigator)) {
-      throw new Error(
-        "This browser doesn’t support the Web Serial API, so board auto-detect isn’t available " +
-          "(Android Chrome is a common case — it has WebUSB but not Web Serial). " +
-          "Please use a desktop computer running Chrome, Edge, Brave, or Opera to flash this board.",
-      );
-    }
     const port = await navigator.serial.requestPort({ filters: RUNNING_USB_FILTERS });
     const board = new SerialBoard(port);
     log("Opening serial connection…");
@@ -774,11 +755,8 @@ function resetUi() {
 }
 
 // ---- Init -------------------------------------------------------------
-let appStarted = false;
-async function startApp() {
-  if (appStarted) return;
-  appStarted = true;
-  el.unsupported.classList.add("hidden");
+async function init() {
+  if (!checkSupport()) return;
   el.app.classList.remove("hidden");
   try {
     manifest = await loadManifest();
@@ -807,14 +785,6 @@ async function startApp() {
   el.btnMonitorCtrlC.onclick = () => monitor && monitor.send("\x03").catch(() => {});
   el.btnMonitorCtrlD.onclick = () => monitor && monitor.send("\x04").catch(() => {});
   setBusy(false);
-}
-
-function init() {
-  // The "Try anyway" escape hatch lets users proceed if our feature detection
-  // is overly cautious (e.g. Android Chrome, which has WebUSB but no Web Serial).
-  el.btnTryAnyway.onclick = startApp;
-  if (!checkSupport()) return;
-  startApp();
 }
 
 init();

--- a/docs/flasher/app.js
+++ b/docs/flasher/app.js
@@ -24,6 +24,7 @@ const $ = (id) => document.getElementById(id);
 const el = {
   unsupported: $("unsupported"),
   unsupportedDetail: $("unsupported-detail"),
+  btnTryAnyway: $("btn-try-anyway"),
   app: $("app"),
   steps: $("steps"),
   progressWrap: $("progress-wrap"),
@@ -153,17 +154,30 @@ function checkSupport() {
   if (hasUsb && hasSerial) return true;
 
   const ua = navigator.userAgent;
+  const isAndroid = /Android/.test(ua);
   let detail =
     "Flashing needs the WebUSB and Web Serial APIs, which are only available in " +
-    "Chromium-based browsers on desktop (Chrome, Edge, Brave, Opera) or Android Chrome.";
+    "Chromium-based browsers on desktop (Chrome, Edge, Brave, Opera) or Android Chrome. " +
+    "If you think this is wrong, tap “Try anyway” to continue.";
   if (/iPhone|iPad|iPod/.test(ua) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)) {
     detail =
       "iPhone and iPad can’t do this — every iOS browser is forced onto Apple’s WebKit engine, " +
       "which has no WebUSB or Web Serial support. Please use a desktop computer running Chrome, Edge, Brave, or Opera.";
+  } else if (isAndroid) {
+    // Android Chrome has WebUSB but not Web Serial, so the all-or-nothing check
+    // above fails. Board auto-detect needs Web Serial, so the workflow is limited
+    // on Android, but allow proceeding in case detection is wrong on this device.
+    detail =
+      "On Android, Chrome supports WebUSB but not the Web Serial API, which the " +
+      "board auto-detect step relies on — so flashing may not fully work here, and a " +
+      "desktop computer running Chrome, Edge, Brave, or Opera is recommended. " +
+      "If you think this is wrong, tap “Try anyway” to continue.";
   } else if (/Firefox/.test(ua)) {
-    detail = "Firefox does not support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera.";
+    detail = "Firefox does not support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera. " +
+      "If you think this is wrong, tap “Try anyway” to continue.";
   } else if (/Safari/.test(ua) && !/Chrome/.test(ua)) {
-    detail = "Safari does not support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera.";
+    detail = "Safari does not support WebUSB or Web Serial. Please use Chrome, Edge, Brave, or Opera. " +
+      "If you think this is wrong, tap “Try anyway” to continue.";
   }
   el.unsupportedDetail.textContent = detail;
   el.unsupported.classList.remove("hidden");
@@ -300,6 +314,13 @@ async function connectAndDetect() {
   clearSteps();
   el.statusAlert.classList.add("hidden");
   try {
+    if (!("serial" in navigator)) {
+      throw new Error(
+        "This browser doesn’t support the Web Serial API, so board auto-detect isn’t available " +
+          "(Android Chrome is a common case — it has WebUSB but not Web Serial). " +
+          "Please use a desktop computer running Chrome, Edge, Brave, or Opera to flash this board.",
+      );
+    }
     const port = await navigator.serial.requestPort({ filters: RUNNING_USB_FILTERS });
     const board = new SerialBoard(port);
     log("Opening serial connection…");
@@ -753,8 +774,11 @@ function resetUi() {
 }
 
 // ---- Init -------------------------------------------------------------
-async function init() {
-  if (!checkSupport()) return;
+let appStarted = false;
+async function startApp() {
+  if (appStarted) return;
+  appStarted = true;
+  el.unsupported.classList.add("hidden");
   el.app.classList.remove("hidden");
   try {
     manifest = await loadManifest();
@@ -783,6 +807,14 @@ async function init() {
   el.btnMonitorCtrlC.onclick = () => monitor && monitor.send("\x03").catch(() => {});
   el.btnMonitorCtrlD.onclick = () => monitor && monitor.send("\x04").catch(() => {});
   setBusy(false);
+}
+
+function init() {
+  // The "Try anyway" escape hatch lets users proceed if our feature detection
+  // is overly cautious (e.g. Android Chrome, which has WebUSB but no Web Serial).
+  el.btnTryAnyway.onclick = startApp;
+  if (!checkSupport()) return;
+  startApp();
 }
 
 init();

--- a/docs/vector/sys11/all.json
+++ b/docs/vector/sys11/all.json
@@ -704,6 +704,14 @@
     "type": "dev"
   },
   {
+    "version": "1.3.4-beta358",
+    "tag": "1.3.4-beta358",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.4-beta358</p>",
+    "published_at": "2025-03-22T20:32:57+00:00",
+    "type": "beta"
+  },
+  {
     "version": "1.3.5-dev67",
     "tag": "1.3.5-dev67",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-dev67/update.json",

--- a/docs/vector/sys11/beta.json
+++ b/docs/vector/sys11/beta.json
@@ -216,6 +216,14 @@
     "type": "beta"
   },
   {
+    "version": "1.3.4-beta358",
+    "tag": "1.3.4-beta358",
+    "url": "https://github.com/warped-pinball/vector/releases/download/1.3.4-beta358/update.json",
+    "notes": "<p>PR: <br>\nBranch: <br>\nVersion: 1.3.4-beta358</p>",
+    "published_at": "2025-03-22T20:32:57+00:00",
+    "type": "beta"
+  },
+  {
     "version": "1.3.5-beta361",
     "tag": "1.3.5-beta361",
     "url": "https://github.com/warped-pinball/vector/releases/download/1.3.5-beta361/update.json",


### PR DESCRIPTION
## Problem

When opening the flasher on an Android phone (Chrome) with a USB-OTG cable, users hit the red **"Your browser can't flash over USB"** banner and can't proceed — even though the banner text claims "Android Chrome" is supported.

**Root cause:** `checkSupport()` required **both** the WebUSB *and* Web Serial APIs:

```js
if (hasUsb && hasSerial) return true;
```

Android Chrome supports **WebUSB but not Web Serial**, so the check always fails on Android, and the message was inaccurate in listing Android as fully supported.

## Changes

- **"Try anyway" escape hatch** — the hard error banner is now a warning with a **Try anyway** button. If our feature detection is overly cautious (an edge-case browser, desktop-mode UA, or a future Android Chrome that adds Web Serial), the user can still reveal the app and proceed. This directly addresses "allow them to try even if we think it isn't supported in case our check is overly sensitive."
- **Accurate Android messaging** — instead of incorrectly claiming Android Chrome is fully supported, the banner now explains Android has WebUSB but not Web Serial (which board auto-detect relies on) and recommends a desktop browser, while still offering Try anyway.
- **Graceful serial-missing message** — if the Connect/auto-detect button is used without Web Serial, the user gets a clear explanation instead of a raw `TypeError`.

## Honest limitation

Board **auto-detect is the only entry point** to the flashing UI, and it relies on Web Serial to read the board's identity. Since Android Chrome lacks Web Serial, a full Android flashing workflow isn't possible without building a WebUSB-only path (manual bootloader entry + manual series selection). That's a larger feature with product decisions attached, so it's out of scope here. This PR removes the incorrect block, tells the truth about Android, and gives users the escape hatch they asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019JSTwhytTSACKxr3a25AE9)_